### PR TITLE
Downgrade Newtonsoft.Json to 9.0.1.

### DIFF
--- a/Octokit.GraphQL.Core/Octokit.GraphQL.Core.csproj
+++ b/Octokit.GraphQL.Core/Octokit.GraphQL.Core.csproj
@@ -9,7 +9,7 @@
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Octokit.GraphQL.nuspec
+++ b/Octokit.GraphQL.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright GitHub 2018</copyright>
     <tags>GitHub API Octokit GraphQL</tags>
     <dependencies>
-      <dependency id="Newtonsoft.Json" version="10.0.3" />
+      <dependency id="Newtonsoft.Json" version="9.0.1" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Given that the only consumer of this library right now is `github/VisualStudio` and that it is recommended to ship with Newtonsoft.Json 9.0.x in VS2017 (see https://github.com/github/VisualStudio/issues/1774), downgrade our dependency to that version. We don't actually need anything from the newer version.

Depends on #107.