### PR TITLE
Adding functionality to specify a PageSize to AllPages

### DIFF
--- a/Octokit.GraphQL.Core.UnitTests/PagingTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/PagingTests.cs
@@ -67,6 +67,34 @@ namespace Octokit.GraphQL.Core.UnitTests
                 Assert.Equal(expected, master.ToString(), ignoreLineEndingDifferences: true);
             }
 
+            [Fact]
+            public void Creates_MasterQuery_CustomPageSize_Expression()
+            {
+                var expected = @"query {
+  repository(owner: ""foo"", name: ""bar"") {
+    id
+    issues(first: 10) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        title
+      }
+    }
+  }
+}";
+
+                var pageSize = 10;
+                var master = new Query()
+                    .Select(query => query.Repository("foo", "bar")
+                        .Issues(null, null, null, null, null)
+                        .AllPages(pageSize).Select(issue => issue.Title).ToList())
+                    .Compile().GetMasterQuery();
+
+                Assert.Equal(expected, master.ToString(), ignoreLineEndingDifferences: true);
+            }
+
             [Fact(Skip = "Need a better way to compare expressions")]
             public void Creates_MasterQuery_Expression()
             {

--- a/Octokit.GraphQL.Core.UnitTests/PagingTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/PagingTests.cs
@@ -23,6 +23,13 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .Select(issue => issue.Number)
                 .Compile();
 
+            ICompiledQuery<IEnumerable<int>> TestQueryCustomSize { get; } = new Query()
+                .Repository("foo", "bar")
+                .Issues()
+                .AllPages()
+                .Select(issue => issue.Number)
+                .Compile();
+
             static Repository_Issues_AllPages()
             {
                 ExpressionCompiler.IsUnitTesting = true;
@@ -47,6 +54,29 @@ namespace Octokit.GraphQL.Core.UnitTests
 }";
 
                 var master = TestQuery.GetMasterQuery();
+
+                Assert.Equal(expected, master.ToString(), ignoreLineEndingDifferences: true);
+            }
+
+            [Fact]
+            public void Creates_MasterQuery_CustomPageSize()
+            {
+                var expected = @"query {
+  repository(owner: ""foo"", name: ""bar"") {
+    id
+    issues(first: 10) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        number
+      }
+    }
+  }
+}";
+
+                var master = TestQueryCustomSize.GetMasterQuery();
 
                 Assert.Equal(expected, master.ToString(), ignoreLineEndingDifferences: true);
             }

--- a/Octokit.GraphQL.Core.UnitTests/PagingTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/PagingTests.cs
@@ -279,7 +279,7 @@ namespace Octokit.GraphQL.Core.UnitTests
                 Assert.Equal(Enumerable.Range(0, 6).ToList(), result);
             }
 
-            private ICompiledQuery<IEnumerable<int>> GetTestQuery()
+            private static ICompiledQuery<IEnumerable<int>> GetTestQuery()
             {
                 return new Query()
                     .Repository("foo", "bar")

--- a/Octokit.GraphQL.Core.UnitTests/PagingTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/PagingTests.cs
@@ -16,13 +16,6 @@ namespace Octokit.GraphQL.Core.UnitTests
 
         public class Repository_Issues_AllPages
         {
-            ICompiledQuery<IEnumerable<int>> TestQuery { get; } = new Query()
-                .Repository("foo", "bar")
-                .Issues()
-                .AllPages()
-                .Select(issue => issue.Number)
-                .Compile();
-
             static Repository_Issues_AllPages()
             {
                 ExpressionCompiler.IsUnitTesting = true;
@@ -46,7 +39,7 @@ namespace Octokit.GraphQL.Core.UnitTests
   }
 }";
 
-                var master = TestQuery.GetMasterQuery();
+                var master = GetTestQuery().GetMasterQuery();
 
                 Assert.Equal(expected, master.ToString(), ignoreLineEndingDifferences: true);
             }
@@ -69,14 +62,7 @@ namespace Octokit.GraphQL.Core.UnitTests
   }
 }";
 
-                var testQueryCustomSize = new Query()
-                    .Repository("foo", "bar")
-                    .Issues()
-                    .AllPages(10)
-                    .Select(issue => issue.Number)
-                    .Compile();
-
-                var master = testQueryCustomSize.GetMasterQuery();
+                var master = GetTestQueryCustomSize().GetMasterQuery();
 
                 Assert.Equal(expected, master.ToString(), ignoreLineEndingDifferences: true);
             }
@@ -92,7 +78,7 @@ namespace Octokit.GraphQL.Core.UnitTests
                         data.Annotation<ISubqueryRunner>(),
                         subqueryPlaceholder));
 
-                var master = TestQuery.GetMasterQuery();
+                var master = GetTestQuery().GetMasterQuery();
 
                 Assert.Equal(expected, master.GetResultBuilderExpression().ToString());
             }
@@ -117,7 +103,33 @@ namespace Octokit.GraphQL.Core.UnitTests
   }
 }";
 
-                var subqueries = TestQuery.GetSubqueries();
+                var subqueries = GetTestQuery().GetSubqueries();
+
+                Assert.Single(subqueries);
+                Assert.Equal(expected, subqueries[0].ToString(), ignoreLineEndingDifferences: true);
+            }
+
+            [Fact]
+            public void Creates_Subquery_CustomPageSize()
+            {
+                var expected = @"query($__id: ID!, $__after: String) {
+  node(id: $__id) {
+    __typename
+    ... on Repository {
+      issues(first: 10, after: $__after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          number
+        }
+      }
+    }
+  }
+}";
+
+                var subqueries = GetTestQueryCustomSize().GetSubqueries();
 
                 Assert.Single(subqueries);
                 Assert.Equal(expected, subqueries[0].ToString(), ignoreLineEndingDifferences: true);
@@ -127,7 +139,7 @@ namespace Octokit.GraphQL.Core.UnitTests
             public void Creates_Subquery_ParentIds_Selector()
             {
                 var expected = Expected(data => data.SelectTokens("$.data.repository.id"));
-                var subqueries = TestQuery.GetSubqueries();
+                var subqueries = GetTestQuery().GetSubqueries();
 
                 Assert.Single(subqueries);
 
@@ -139,7 +151,7 @@ namespace Octokit.GraphQL.Core.UnitTests
             public void Creates_Subquery_PageInfo_Selector()
             {
                 var expected = Expected(data => data.SelectToken("data.node.issues.pageInfo"));
-                var subqueries = TestQuery.GetSubqueries();
+                var subqueries = GetTestQuery().GetSubqueries();
 
                 Assert.Single(subqueries);
 
@@ -151,7 +163,7 @@ namespace Octokit.GraphQL.Core.UnitTests
             public void Creates_Subquery_ParentPageInfo_Selector()
             {
                 var expected = Expected(data => data.SelectTokens("$.data.repository.issues.pageInfo"));
-                var subqueries = TestQuery.GetSubqueries();
+                var subqueries = GetTestQuery().GetSubqueries();
 
                 Assert.Single(subqueries);
 
@@ -234,9 +246,30 @@ namespace Octokit.GraphQL.Core.UnitTests
                 }
 
                 var connection = new MockConnection(Execute);
-                var result = (await connection.Run(TestQuery)).ToList();
+                var result = (await connection.Run(GetTestQuery())).ToList();
 
                 Assert.Equal(Enumerable.Range(0, 6).ToList(), result);
+            }
+
+            private ICompiledQuery<IEnumerable<int>> GetTestQuery()
+            {
+                return new Query()
+                    .Repository("foo", "bar")
+                    .Issues()
+                    .AllPages()
+                    .Select(issue => issue.Number)
+                    .Compile();
+            }
+
+            private static ICompiledQuery<IEnumerable<int>> GetTestQueryCustomSize()
+            {
+                var testQueryCustomSize = new Query()
+                    .Repository("foo", "bar")
+                    .Issues()
+                    .AllPages(10)
+                    .Select(issue => issue.Number)
+                    .Compile();
+                return testQueryCustomSize;
             }
         }
 

--- a/Octokit.GraphQL.Core.UnitTests/PagingTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/PagingTests.cs
@@ -23,13 +23,6 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .Select(issue => issue.Number)
                 .Compile();
 
-            ICompiledQuery<IEnumerable<int>> TestQueryCustomSize { get; } = new Query()
-                .Repository("foo", "bar")
-                .Issues()
-                .AllPages()
-                .Select(issue => issue.Number)
-                .Compile();
-
             static Repository_Issues_AllPages()
             {
                 ExpressionCompiler.IsUnitTesting = true;
@@ -76,7 +69,14 @@ namespace Octokit.GraphQL.Core.UnitTests
   }
 }";
 
-                var master = TestQueryCustomSize.GetMasterQuery();
+                var testQueryCustomSize = new Query()
+                    .Repository("foo", "bar")
+                    .Issues()
+                    .AllPages(10)
+                    .Select(issue => issue.Number)
+                    .Compile();
+
+                var master = testQueryCustomSize.GetMasterQuery();
 
                 Assert.Equal(expected, master.ToString(), ignoreLineEndingDifferences: true);
             }

--- a/Octokit.GraphQL.Core/Core/Builders/AllPagesExpression.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/AllPagesExpression.cs
@@ -12,8 +12,7 @@ namespace Octokit.GraphQL.Core.Builders
         /// Initializes a new instance of the <see cref="AllPagesExpression"/> class.
         /// </summary>
         /// <param name="method">The method that AllPages() was called on.</param>
-        /// <param name="constant">The constant expression that AllPages was given for
-        /// </param>
+        /// <param name="constant">The ConstantExpression that AllPages was sent</param>
         public AllPagesExpression(MethodCallExpression method, ConstantExpression constant = null)
         {
             Method = method;
@@ -25,6 +24,9 @@ namespace Octokit.GraphQL.Core.Builders
         /// </summary>
         public MethodCallExpression Method { get; }
 
+        /// <summary>
+        /// Gets the constant value that was sent to AllPages
+        /// </summary>
         public ConstantExpression Constant { get; }
 
         /// <inheritdoc/>

--- a/Octokit.GraphQL.Core/Core/Builders/AllPagesExpression.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/AllPagesExpression.cs
@@ -12,11 +12,11 @@ namespace Octokit.GraphQL.Core.Builders
         /// Initializes a new instance of the <see cref="AllPagesExpression"/> class.
         /// </summary>
         /// <param name="method">The method that AllPages() was called on.</param>
-        /// <param name="constant">The ConstantExpression that AllPages was sent</param>
-        public AllPagesExpression(MethodCallExpression method, ConstantExpression constant = null)
+        /// <param name="pageSize">The ConstantExpression that AllPages was sent</param>
+        public AllPagesExpression(MethodCallExpression method, ConstantExpression pageSize = null)
         {
             Method = method;
-            Constant = constant;
+            PageSize = pageSize;
         }
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace Octokit.GraphQL.Core.Builders
         /// <summary>
         /// Gets the constant value that was sent to AllPages
         /// </summary>
-        public ConstantExpression Constant { get; }
+        public ConstantExpression PageSize { get; }
 
         /// <inheritdoc/>
         public override ExpressionType NodeType => ExpressionType.Extension;

--- a/Octokit.GraphQL.Core/Core/Builders/AllPagesExpression.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/AllPagesExpression.cs
@@ -12,12 +12,20 @@ namespace Octokit.GraphQL.Core.Builders
         /// Initializes a new instance of the <see cref="AllPagesExpression"/> class.
         /// </summary>
         /// <param name="method">The method that AllPages() was called on.</param>
-        public AllPagesExpression(MethodCallExpression method) => Method = method;
+        /// <param name="constant">The constant expression that AllPages was given for
+        /// </param>
+        public AllPagesExpression(MethodCallExpression method, ConstantExpression constant = null)
+        {
+            Method = method;
+            Constant = constant;
+        }
 
         /// <summary>
         /// Gets the method that AllPages() was called on.
         /// </summary>
         public MethodCallExpression Method { get; }
+
+        public ConstantExpression Constant { get; }
 
         /// <inheritdoc/>
         public override ExpressionType NodeType => ExpressionType.Extension;

--- a/Octokit.GraphQL.Core/Core/Builders/AllPagesExpression.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/AllPagesExpression.cs
@@ -13,7 +13,7 @@ namespace Octokit.GraphQL.Core.Builders
         /// </summary>
         /// <param name="method">The method that AllPages() was called on.</param>
         /// <param name="pageSize">The ConstantExpression that AllPages was sent</param>
-        public AllPagesExpression(MethodCallExpression method, ConstantExpression pageSize = null)
+        public AllPagesExpression(MethodCallExpression method, int? pageSize = null)
         {
             Method = method;
             PageSize = pageSize;
@@ -25,9 +25,9 @@ namespace Octokit.GraphQL.Core.Builders
         public MethodCallExpression Method { get; }
 
         /// <summary>
-        /// Gets the constant value that was sent to AllPages
+        /// Gets the value that was sent to AllPages
         /// </summary>
-        public ConstantExpression PageSize { get; }
+        public int? PageSize { get; }
 
         /// <inheritdoc/>
         public override ExpressionType NodeType => ExpressionType.Extension;

--- a/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
@@ -599,7 +599,7 @@ namespace Octokit.GraphQL.Core.Builders
                     parentIds = CreateSelectTokensExpression(
                         parentSelection.Select(x => x.Name).Concat(new[] { "id" }));
 
-                    var pageSize = (int?)allPages.Constant?.Value ?? MaxPageSize;
+                    var pageSize = (int?)allPages.PageSize?.Value ?? MaxPageSize;
 
                     // Add a "first: pageSize" argument to the query field.
                     syntax.AddArgument("first", pageSize);

--- a/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
@@ -793,7 +793,8 @@ namespace Octokit.GraphQL.Core.Builders
             }
         }
 
-        private ISubquery AddSubquery(MethodCallExpression expression,
+        private ISubquery AddSubquery(
+            MethodCallExpression expression,
             MethodCallExpression selector,
             Expression pageInfoSelector,
             int pageSize)
@@ -817,7 +818,8 @@ namespace Octokit.GraphQL.Core.Builders
                 JsonMethods.JTokenAnnotation.MakeGenericMethod(typeof(ISubqueryRunner)));
         }
 
-        private Expression CreateNodeQuery(MethodCallExpression expression,
+        private Expression CreateNodeQuery(
+            MethodCallExpression expression,
             MethodCallExpression selector,
             int pageSize)
         {
@@ -872,7 +874,8 @@ namespace Octokit.GraphQL.Core.Builders
                 new[] { rewritten, selector.Arguments[1] });
         }
 
-        MethodCallExpression RewritePagingMethodCall(MethodCallExpression methodCall,
+        MethodCallExpression RewritePagingMethodCall(
+            MethodCallExpression methodCall,
             Expression instance, 
             int pageSize)
         {

--- a/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
@@ -740,9 +740,6 @@ namespace Octokit.GraphQL.Core.Builders
             }
             else if (expression.Method.GetGenericMethodDefinition() == PagingConnectionExtensions.AllPagesCustomSizeMethod)
             {
-                // .AllPages() was called on a IPagingConnection. We can't handle this yet -
-                // return an AllPagesExpression so we know to handle it when the containing Select
-                // is visited.
                 return new AllPagesExpression((MethodCallExpression)expression.Arguments[0], (ConstantExpression)expression.Arguments[1]);
             }
             else
@@ -798,7 +795,8 @@ namespace Octokit.GraphQL.Core.Builders
 
         private ISubquery AddSubquery(MethodCallExpression expression,
             MethodCallExpression selector,
-            Expression pageInfoSelector, int pageSize)
+            Expression pageInfoSelector,
+            int pageSize)
         {
             // Create a lambda that selects the "pageInfo" fields.
             var parentPageInfo = CreatePageInfoExpression();
@@ -820,7 +818,8 @@ namespace Octokit.GraphQL.Core.Builders
         }
 
         private Expression CreateNodeQuery(MethodCallExpression expression,
-            MethodCallExpression selector, int pageSize)
+            MethodCallExpression selector,
+            int pageSize)
         {
             // Given an expression such as:
             //
@@ -874,7 +873,8 @@ namespace Octokit.GraphQL.Core.Builders
         }
 
         MethodCallExpression RewritePagingMethodCall(MethodCallExpression methodCall,
-            Expression instance, int pageSize)
+            Expression instance, 
+            int pageSize)
         {
             var arguments = new List<Expression>();
             var i = 0;

--- a/Octokit.GraphQL.Core/PagingConnectionExtensions.cs
+++ b/Octokit.GraphQL.Core/PagingConnectionExtensions.cs
@@ -23,15 +23,14 @@ namespace Octokit.GraphQL
                     new Expression[] { source.Expression }));
         }
 
-        [MethodId(nameof(AllPagesCustomSizeMethod))]
+        [MethodId(nameof(AllPages))]
         public static IQueryableList<TResult> AllPages<TResult>(this IPagingConnection<TResult> source, int pageSize)
             where TResult : IQueryableValue
         {
-            return new QueryableList<TResult>(
-                Expression.Call(
-                    null,
-                    GetMethodInfoOf(() => AllPages<TResult>(default, pageSize)),
-                    new Expression[] { source.Expression }));
+            return new QueryableList<TResult>(Expression.Call(
+                null,
+                GetMethodInfoOf(() => AllPages<TResult>(default, pageSize)), 
+                new Expression[]{ source.Expression, Expression.Constant(pageSize) }));
         }
 
         private static MethodInfo GetMethodInfo(string id, int parameterCount)

--- a/Octokit.GraphQL.Core/PagingConnectionExtensions.cs
+++ b/Octokit.GraphQL.Core/PagingConnectionExtensions.cs
@@ -9,7 +9,8 @@ namespace Octokit.GraphQL
 {
     public static class PagingConnectionExtensions
     {
-        public static readonly MethodInfo AllPagesMethod = GetMethodInfo(nameof(AllPages));
+        public static readonly MethodInfo AllPagesMethod = GetMethodInfo(nameof(AllPages), 1);
+        public static readonly MethodInfo AllPagesCustomSizeMethod = GetMethodInfo(nameof(AllPages), 2);
 
         [MethodId(nameof(AllPages))]
         public static IQueryableList<TResult> AllPages<TResult>(this IPagingConnection<TResult> source)
@@ -22,12 +23,23 @@ namespace Octokit.GraphQL
                     new Expression[] { source.Expression }));
         }
 
-        private static MethodInfo GetMethodInfo(string id)
+        [MethodId(nameof(AllPagesCustomSizeMethod))]
+        public static IQueryableList<TResult> AllPages<TResult>(this IPagingConnection<TResult> source, int pageSize)
+            where TResult : IQueryableValue
+        {
+            return new QueryableList<TResult>(
+                Expression.Call(
+                    null,
+                    GetMethodInfoOf(() => AllPages<TResult>(default, pageSize)),
+                    new Expression[] { source.Expression }));
+        }
+
+        private static MethodInfo GetMethodInfo(string id, int parameterCount)
         {
             return typeof(PagingConnectionExtensions)
                 .GetTypeInfo()
                 .DeclaredMethods
-                .Where(x => x.GetCustomAttribute<MethodIdAttribute>()?.Id == id)
+                .Where(x => x.GetCustomAttribute<MethodIdAttribute>()?.Id == id && x.GetParameters().Length == parameterCount)
                 .SingleOrDefault();
         }
 


### PR DESCRIPTION
- Functionality to provide a custom page size when using `AllPages`

This is integral when dealing with very large queries. Queries are limited by the amount of objects they can **_possibly_** return. Not by how many objects they actually return.

Using `AllPages(int)` will allow the user to change the `$first` value and reduce the possible combination in order to craft an operational query.