### PR TITLE
GraphQL Checks API requires preview header

### DIFF
--- a/Octokit.GraphQL.Core/Connection.cs
+++ b/Octokit.GraphQL.Core/Connection.cs
@@ -63,10 +63,11 @@ namespace Octokit.GraphQL
 
         private HttpClient CreateHttpClient(ProductHeaderValue header)
         {
-            var result = new HttpClient();
+            var httpClient = new HttpClient();
             var userAgent = new ProductInfoHeaderValue(header.Name, header.Version);
-            result.DefaultRequestHeaders.UserAgent.Add(userAgent);
-            return result;
+            httpClient.DefaultRequestHeaders.UserAgent.Add(userAgent);
+            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github.antiope-preview+json"));
+            return httpClient;
         }
     }
 }


### PR DESCRIPTION
The GraphQL Checks API was previously exposed without correctly applying the preview header.
It explains why we were able to access the Checks API so early.

https://developer.github.com/v4/previews/#checks