### PR TITLE
HttpClient injection

### DIFF
--- a/Octokit.GraphQL.Core.UnitTests/ConnectionTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/ConnectionTests.cs
@@ -160,7 +160,7 @@ namespace Octokit.GraphQL.Core.UnitTests
 
         private sealed class MockCredentialStore : ICredentialStore
         {
-            public Task<string> GetCredentials() => Task.FromResult("my-token");
+            public Task<string> GetCredentials(CancellationToken cancellationToken) => Task.FromResult("my-token");
         }
     }
 }

--- a/Octokit.GraphQL.Core.UnitTests/ConnectionTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/ConnectionTests.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Octokit.GraphQL.Core.UnitTests
+{
+    public static class ConnectionTests
+    {
+        private static readonly ICredentialStore CredentialStore = new MockCredentialStore();
+        private static readonly ProductHeaderValue ProductInformation = new ProductHeaderValue("Octokit.GraphQL.Core.Tests", "1.0.0");
+
+        [Fact]
+        public static void Default_GraphQL_Uri_Is_Correct()
+        {
+            Assert.Equal("https://api.github.com/graphql", Connection.GithubApiUri?.ToString());
+        }
+
+        [Fact]
+        public static void Connection_Constructor_Validates_Arguments_For_Null()
+        {
+            var productInformation = ProductInformation;
+            var uri = new Uri("https://api.github.enterprise.local/graphql");
+            var credentialStore = CredentialStore;
+            var httpClient = new HttpClient();
+
+            Assert.Throws<ArgumentNullException>("productInformation", () => new Connection(null, uri, credentialStore, httpClient));
+            Assert.Throws<ArgumentNullException>("uri", () => new Connection(productInformation, null, credentialStore, httpClient));
+            Assert.Throws<ArgumentNullException>("credentialStore", () => new Connection(productInformation, uri, null, httpClient));
+            Assert.Throws<ArgumentNullException>("httpClient", () => new Connection(productInformation, uri, credentialStore, null));
+        }
+
+        [Fact]
+        public static void Connection_Constructor_Throws_If_Uri_Is_Relative()
+        {
+            var productInformation = ProductInformation;
+            var uri = new Uri("/graphql", UriKind.Relative);
+            var credentialStore = CredentialStore;
+
+            var exception = Assert.Throws<ArgumentException>("uri", () => new Connection(productInformation, uri, credentialStore));
+            Assert.StartsWith("The base address for the connection must be an absolute URI.", exception.Message);
+        }
+
+        [Fact]
+        public static void Connection_Constructors_With_No_Uri_Parameter_Use_GitHub_GraphQL_Uri()
+        {
+            var connection = new Connection(ProductInformation, "token");
+            Assert.Equal(Connection.GithubApiUri, connection.Uri);
+
+            connection = new Connection(ProductInformation, CredentialStore);
+            Assert.Equal(Connection.GithubApiUri, connection.Uri);
+
+            connection = new Connection(ProductInformation, CredentialStore, new HttpClient());
+            Assert.Equal(Connection.GithubApiUri, connection.Uri);
+        }
+
+        [Fact]
+        public static async Task Run_Specifies_Cancellation_Token()
+        {
+            var query = "{}";
+            var cancellationToken = new CancellationToken(true);
+
+            var httpClient = CreateFakeHttpClient(
+                (request, token) =>
+                {
+                    Assert.True(token.IsCancellationRequested);
+                });
+
+            var connection = new Connection(ProductInformation, CredentialStore, httpClient);
+
+            await connection.Run(query, cancellationToken);
+        }
+
+        [Theory]
+        [InlineData("Accept", "application/vnd.github.antiope-preview+json")]
+        [InlineData("Authorization", "bearer my-token")]
+        [InlineData("User-Agent", "Octokit.GraphQL.Core.Tests/1.0.0")]
+        public static async Task Run_Specifies_Http_Headers(string name, string expected)
+        {
+            var query = "{}";
+
+            var httpClient = CreateFakeHttpClient(
+                (request, token) =>
+                {
+                    Assert.Equal(expected, string.Concat(request.Headers.GetValues(name)));
+                });
+
+            var connection = new Connection(ProductInformation, CredentialStore, httpClient);
+
+            await connection.Run(query);
+        }
+
+        [Fact]
+        public static void Run_Throws_If_Query_Is_Null()
+        {
+            var connection = new Connection(ProductInformation, CredentialStore);
+            Assert.ThrowsAsync<ArgumentNullException>("query", () => connection.Run(null));
+        }
+
+        [Fact]
+        public static async Task Run_Throws_If_Http_Request_Does_Not_Return_An_Http_2xx_Response_Code()
+        {
+            var httpClient = CreateFakeHttpClient(statusCode: HttpStatusCode.BadRequest);
+            var connection = new Connection(ProductInformation, CredentialStore);
+            var query = "{}";
+
+            await Assert.ThrowsAsync<HttpRequestException>(() => connection.Run(query));
+        }
+
+        [Fact]
+        public static async Task Run_Uses_The_Specified_Uri()
+        {
+            var productInformation = ProductInformation;
+            var uri = new Uri("https://api.github.enterprise.local/graphql");
+            var credentialStore = CredentialStore;
+            var query = "{}";
+
+            var httpClient = CreateFakeHttpClient(
+                (request, token) =>
+                {
+                    Assert.Equal(uri, request.RequestUri);
+                });
+
+            var connection = new Connection(ProductInformation, uri, CredentialStore, httpClient);
+
+            await connection.Run(query);
+        }
+
+        private static HttpClient CreateFakeHttpClient(Action<HttpRequestMessage, CancellationToken> inspector = null, HttpStatusCode statusCode = HttpStatusCode.OK)
+        {
+            var handler = new MockHttpMessageHandler(inspector, statusCode);
+            return new HttpClient(handler);
+        }
+
+        private sealed class MockHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly Action<HttpRequestMessage, CancellationToken> _inspector;
+            private readonly HttpStatusCode _statusCode;
+
+            public MockHttpMessageHandler(Action<HttpRequestMessage, CancellationToken> inspector, HttpStatusCode statusCode = HttpStatusCode.OK)
+            {
+                _inspector = inspector;
+                _statusCode = statusCode;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                _inspector?.Invoke(request, cancellationToken);
+
+                var response = new HttpResponseMessage(_statusCode)
+                {
+                    Content = new StringContent(string.Empty)
+                };
+
+                return Task.FromResult(response);
+            }
+        }
+
+        private sealed class MockCredentialStore : ICredentialStore
+        {
+            public Task<string> GetCredentials() => Task.FromResult("my-token");
+        }
+    }
+}

--- a/Octokit.GraphQL.Core.UnitTests/MockConnection.cs
+++ b/Octokit.GraphQL.Core.UnitTests/MockConnection.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -23,7 +24,7 @@ namespace Octokit.GraphQL.Core.UnitTests
             return deserialize(JObject.Parse(result));
         }
 
-        public Task<string> Run(string query)
+        public Task<string> Run(string query, CancellationToken cancellationToken = default)
         {
             var payload = JsonConvert.DeserializeObject<Payload>(query);
             return Task.FromResult(execute(payload.Query, payload.Variables));

--- a/Octokit.GraphQL.Core/Connection.cs
+++ b/Octokit.GraphQL.Core/Connection.cs
@@ -213,8 +213,7 @@ namespace Octokit.GraphQL
                 throw new ArgumentNullException(nameof(query));
             }
 
-            // TODO Pass through cancellationToken here too?
-            var token = await CredentialStore.GetCredentials().ConfigureAwait(false);
+            var token = await CredentialStore.GetCredentials(cancellationToken).ConfigureAwait(false);
 
             using (var request = CreateRequest(token, query))
             {

--- a/Octokit.GraphQL.Core/Connection.cs
+++ b/Octokit.GraphQL.Core/Connection.cs
@@ -1,97 +1,249 @@
 ﻿using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Octokit.GraphQL.Internal;
 
 namespace Octokit.GraphQL
 {
-    /// <inheritdoc />
+    /// <summary>
+    /// A connection for making HTTP requests against the GitHub GraphQL API endpoint.
+    /// </summary>
     public class Connection : IConnection
     {
-        /// <summary>
-        /// The address of the GitHub GraphQL API.
-        /// </summary>
-        public static readonly Uri GithubApiUri = new Uri("https://api.github.com/graphql");
+        private const string DefaultMediaType = "application/vnd.github.antiope-preview+json";
 
+        /// <summary>
+        /// Gets the address of the GitHub GraphQL API.
+        /// </summary>
+        public static Uri GithubApiUri { get; } = new Uri("https://api.github.com/graphql");
+
+        /// <summary>
+        /// Creates a new connection instance used to make requests of the GitHub GraphQL API.
+        /// </summary>
+        /// <remarks>
+        /// See more information regarding User-Agent requirements here: https://developer.github.com/v3/#user-agent-required.
+        /// </remarks>
+        /// <param name="productInformation">
+        /// The name (and optionally version) of the product using this library, the name of your GitHub organization, or your GitHub username (in that order of preference). This is sent to the server as part of
+        /// the user agent for analytics purposes, and used by GitHub to contact you if there are problems.
+        /// </param>
+        /// <param name="token">The token to use to authenticate with the GitHub GraphQL API.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="productInformation"/> is <see langword="null"/>.
+        /// </exception>
         public Connection(ProductHeaderValue productInformation, string token)
             : this(productInformation, GithubApiUri, token)
         {
         }
 
+        /// <summary>
+        /// Creates a new connection instance used to make requests of the GitHub GraphQL API.
+        /// </summary>
+        /// <remarks>
+        /// See more information regarding User-Agent requirements here: https://developer.github.com/v3/#user-agent-required.
+        /// </remarks>
+        /// <param name="productInformation">
+        /// The name (and optionally version) of the product using this library, the name of your GitHub organization, or your GitHub username (in that order of preference). This is sent to the server as part of
+        /// the user agent for analytics purposes, and used by GitHub to contact you if there are problems.
+        /// </param>
+        /// <param name="uri">
+        /// The address to point this client to such as https://api.github.com or the URL to a GitHub Enterprise instance.
+        /// </param>
+        /// <param name="token">The token to use to authenticate with the GitHub GraphQL API.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="uri"/> is not an absolute URI.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="productInformation"/> or <paramref name="uri"/> are <see langword="null"/>.
+        /// </exception>
         public Connection(ProductHeaderValue productInformation, Uri uri, string token)
             : this(productInformation, uri, new InMemoryCredentialStore(token))
         {
         }
 
+        /// <summary>
+        /// Creates a new connection instance used to make requests of the GitHub GraphQL API.
+        /// </summary>
+        /// <remarks>
+        /// See more information regarding User-Agent requirements here: https://developer.github.com/v3/#user-agent-required.
+        /// </remarks>
+        /// <param name="productInformation">
+        /// The name (and optionally version) of the product using this library, the name of your GitHub organization, or your GitHub username (in that order of preference). This is sent to the server as part of
+        /// the user agent for analytics purposes, and used by GitHub to contact you if there are problems.
+        /// </param>
+        /// <param name="credentialStore">Provides credentials to the client when making requests.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="productInformation"/> or <paramref name="credentialStore"/> are <see langword="null"/>.
+        /// </exception>
         public Connection(ProductHeaderValue productInformation, ICredentialStore credentialStore)
             : this(productInformation, GithubApiUri, credentialStore)
         {
         }
 
+        /// <summary>
+        /// Creates a new connection instance used to make requests of the GitHub GraphQL API.
+        /// </summary>
+        /// <remarks>
+        /// See more information regarding User-Agent requirements here: https://developer.github.com/v3/#user-agent-required.
+        /// </remarks>
+        /// <param name="productInformation">
+        /// The name (and optionally version) of the product using this library, the name of your GitHub organization, or your GitHub username (in that order of preference). This is sent to the server as part of
+        /// the user agent for analytics purposes, and used by GitHub to contact you if there are problems.
+        /// </param>
+        /// <param name="uri">
+        /// The address to point this client to such as https://api.github.com or the URL to a GitHub Enterprise instance.
+        /// </param>
+        /// <param name="credentialStore">Provides credentials to the client when making requests.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="uri"/> is not an absolute URI.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="productInformation"/>, <paramref name="uri"/> or <paramref name="credentialStore"/> are <see langword="null"/>.
+        /// </exception>
         public Connection(ProductHeaderValue productInformation, Uri uri, ICredentialStore credentialStore)
+            : this(productInformation, uri, credentialStore, new HttpClient())
         {
-            Uri = uri;
-            CredentialStore = credentialStore;
-            HttpClient = CreateHttpClient(productInformation);
         }
 
-        /// <inheritdoc />
-        public Connection(HttpClient httpClient, ICredentialStore credentialStore)
+        /// <summary>
+        /// Creates a new connection instance used to make requests of the GitHub GraphQL API.
+        /// </summary>
+        /// <remarks>
+        /// See more information regarding User-Agent requirements here: https://developer.github.com/v3/#user-agent-required.
+        /// </remarks>
+        /// <param name="productInformation">
+        /// The name (and optionally version) of the product using this library, the name of your GitHub organization, or your GitHub username (in that order of preference). This is sent to the server as part of
+        /// the user agent for analytics purposes, and used by GitHub to contact you if there are problems.
+        /// </param>
+        /// <param name="credentialStore">Provides credentials to the client when making requests.</param>
+        /// <param name="httpClient">An <see cref="HttpClient"/> used to make requests.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="productInformation"/>, <paramref name="credentialStore"/> or <paramref name="httpClient"/> are <see langword="null"/>.
+        /// </exception>
+        public Connection(ProductHeaderValue productInformation, ICredentialStore credentialStore, HttpClient httpClient)
+            : this(productInformation, GithubApiUri, credentialStore, httpClient)
         {
-            HttpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
-            CredentialStore = credentialStore ?? throw new ArgumentNullException(nameof(credentialStore));
+        }
 
-            if (httpClient.BaseAddress == null)
+        /// <summary>
+        /// Creates a new connection instance used to make requests of the GitHub GraphQL API.
+        /// </summary>
+        /// <remarks>
+        /// See more information regarding User-Agent requirements here: https://developer.github.com/v3/#user-agent-required.
+        /// </remarks>
+        /// <param name="productInformation">
+        /// The name (and optionally version) of the product using this library, the name of your GitHub organization, or your GitHub username (in that order of preference). This is sent to the server as part of
+        /// the user agent for analytics purposes, and used by GitHub to contact you if there are problems.
+        /// </param>
+        /// <param name="uri">
+        /// The address to point this client to such as https://api.github.com or the URL to a GitHub Enterprise instance.
+        /// </param>
+        /// <param name="credentialStore">Provides credentials to the client when making requests.</param>
+        /// <param name="httpClient">An <see cref="HttpClient"/> used to make requests.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="uri"/> is not an absolute URI.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="productInformation"/>, <paramref name="uri"/>, <paramref name="credentialStore"/> or <paramref name="httpClient"/> are <see langword="null"/>.
+        /// </exception>
+        public Connection(
+            ProductHeaderValue productInformation,
+            Uri uri,
+            ICredentialStore credentialStore,
+            HttpClient httpClient)
+        {
+            if (productInformation == null)
             {
-                httpClient.BaseAddress = GithubApiUri;
+                throw new ArgumentNullException(nameof(productInformation));
             }
 
-            Uri = httpClient.BaseAddress;
+            Uri = uri ?? throw new ArgumentNullException(nameof(uri));
+            CredentialStore = credentialStore ?? throw new ArgumentNullException(nameof(credentialStore));
+            HttpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+
+            if (!Uri.IsAbsoluteUri)
+            {
+                throw new ArgumentException("The base address for the connection must be an absolute URI.", nameof(uri));
+            }
+
+            Accept = new MediaTypeWithQualityHeaderValue(DefaultMediaType);
+            UserAgent = new ProductInfoHeaderValue(productInformation.Name, productInformation.Version);
         }
 
+        /// <summary>
+        /// Gets the base URI for the connection.
+        /// </summary>
         public Uri Uri { get; }
+
+        /// <summary>
+        /// Gets the credential store for the connection.
+        /// </summary>
         protected ICredentialStore CredentialStore { get; }
+
+        /// <summary>
+        /// Gets the HTTP client for the connection.
+        /// </summary>
         protected HttpClient HttpClient { get; }
 
-        public async Task<string> Run(string query)
+        /// <summary>
+        /// Gets the Accept value for the connection.
+        /// </summary>
+        private MediaTypeWithQualityHeaderValue Accept { get; }
+
+        /// <summary>
+        /// Gets the User Agent value for the connection.
+        /// </summary>
+        private ProductInfoHeaderValue UserAgent { get; }
+
+        /// <summary>
+        /// Runs the specified GraphQL query as an asynchronous operation.
+        /// </summary>
+        /// <param name="query">The GraphQL query to run.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation that returns the result of the GraphQL query.
+        /// </returns>
+        public async Task<string> Run(string query, CancellationToken cancellationToken = default)
         {
-            var token = await CredentialStore.GetCredentials();
-
-            using (var request = new HttpRequestMessage(HttpMethod.Post, Uri))
+            if (query == null)
             {
-                request.Content = new StringContent(query);
-                request.Headers.Authorization = new AuthenticationHeaderValue("bearer", token);
+                throw new ArgumentNullException(nameof(query));
+            }
 
-                using (var response = await HttpClient.SendAsync(request))
+            var token = await CredentialStore.GetCredentials().ConfigureAwait(false);
+
+            using (var request = CreateRequest(token, query))
+            {
+                using (var response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     response.EnsureSuccessStatusCode();
-                    return await response.Content.ReadAsStringAsync();
+                    return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 }
             }
         }
 
-        private static void ConfigureHttpClient(HttpClient httpClient, ProductHeaderValue header)
+        private HttpRequestMessage CreateRequest(string token, string query)
         {
-            if (httpClient.DefaultRequestHeaders.UserAgent.Count == 0)
+            var request = new HttpRequestMessage(HttpMethod.Post, Uri);
+
+            try
             {
-                var userAgent = new ProductInfoHeaderValue(header.Name, header.Version);
-                httpClient.DefaultRequestHeaders.UserAgent.Add(userAgent);
-            }
+                request.Headers.Authorization = new AuthenticationHeaderValue("bearer", token);
+                request.Headers.Accept.Add(Accept);
+                request.Headers.UserAgent.Add(UserAgent);
 
-            if (httpClient.DefaultRequestHeaders.Accept.Count == 0)
+                request.Content = new StringContent(query, Encoding.UTF8);
+
+                return request;
+            }
+            catch (Exception)
             {
-                httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github.antiope-preview+json"));
+                request.Dispose();
+                throw;
             }
-        }
-
-        private static HttpClient CreateHttpClient(ProductHeaderValue header)
-        {
-            var httpClient = new HttpClient();
-
-            ConfigureHttpClient(httpClient, header);
-
-            return httpClient;
         }
     }
 }

--- a/Octokit.GraphQL.Core/Connection.cs
+++ b/Octokit.GraphQL.Core/Connection.cs
@@ -213,6 +213,7 @@ namespace Octokit.GraphQL
                 throw new ArgumentNullException(nameof(query));
             }
 
+            // TODO Pass through cancellationToken here too?
             var token = await CredentialStore.GetCredentials().ConfigureAwait(false);
 
             using (var request = CreateRequest(token, query))

--- a/Octokit.GraphQL.Core/Connection.cs
+++ b/Octokit.GraphQL.Core/Connection.cs
@@ -173,9 +173,7 @@ namespace Octokit.GraphQL
             UserAgent = new ProductInfoHeaderValue(productInformation.Name, productInformation.Version);
         }
 
-        /// <summary>
-        /// Gets the base URI for the connection.
-        /// </summary>
+        /// <inheritdoc />
         public Uri Uri { get; }
 
         /// <summary>
@@ -198,14 +196,7 @@ namespace Octokit.GraphQL
         /// </summary>
         private ProductInfoHeaderValue UserAgent { get; }
 
-        /// <summary>
-        /// Runs the specified GraphQL query as an asynchronous operation.
-        /// </summary>
-        /// <param name="query">The GraphQL query to run.</param>
-        /// <param name="cancellationToken">The optional cancellation token to use.</param>
-        /// <returns>
-        /// A <see cref="Task{TResult}"/> representing the asynchronous operation that returns the result of the GraphQL query.
-        /// </returns>
+        /// <inheritdoc />
         public virtual async Task<string> Run(string query, CancellationToken cancellationToken = default)
         {
             if (query == null)

--- a/Octokit.GraphQL.Core/Connection.cs
+++ b/Octokit.GraphQL.Core/Connection.cs
@@ -206,7 +206,7 @@ namespace Octokit.GraphQL
         /// <returns>
         /// A <see cref="Task{TResult}"/> representing the asynchronous operation that returns the result of the GraphQL query.
         /// </returns>
-        public async Task<string> Run(string query, CancellationToken cancellationToken = default)
+        public virtual async Task<string> Run(string query, CancellationToken cancellationToken = default)
         {
             if (query == null)
             {

--- a/Octokit.GraphQL.Core/IConnection.cs
+++ b/Octokit.GraphQL.Core/IConnection.cs
@@ -1,12 +1,27 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octokit.GraphQL
 {
+    /// <summary>
+    /// Defines a connection for making HTTP requests against the GitHub GraphQL API endpoint.
+    /// </summary>
     public interface IConnection
     {
+        /// <summary>
+        /// Gets the base URI for the connection.
+        /// </summary>
         Uri Uri { get; }
 
-        Task<string> Run(string query);
+        /// <summary>
+        /// Runs the specified GraphQL query as an asynchronous operation.
+        /// </summary>
+        /// <param name="query">The GraphQL query to run.</param>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> representing the asynchronous operation that returns the result of the GraphQL query.
+        /// </returns>
+        Task<string> Run(string query, CancellationToken cancellationToken = default);
     }
 }

--- a/Octokit.GraphQL.Core/ICredentialStore.cs
+++ b/Octokit.GraphQL.Core/ICredentialStore.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
 namespace Octokit.GraphQL
 {
@@ -10,7 +11,8 @@ namespace Octokit.GraphQL
         /// <summary>
         /// Retrieve the credentials from the underlying store
         /// </summary>
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
         /// <returns>A continuation containing credentials</returns>
-        Task<string> GetCredentials();
+        Task<string> GetCredentials(CancellationToken cancellationToken = default);
     }
 }

--- a/Octokit.GraphQL.Core/Internal/InMemoryCredentialStore.cs
+++ b/Octokit.GraphQL.Core/Internal/InMemoryCredentialStore.cs
@@ -1,12 +1,31 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octokit.GraphQL.Internal
 {
+    /// <summary>
+    /// An in memory credential store
+    /// </summary>
     public class InMemoryCredentialStore : ICredentialStore
     {
         readonly string token;
-        public InMemoryCredentialStore(string token) => this.token = token;
+
+        /// <summary>
+        /// Construct an in memory credential store
+        /// </summary>
+        /// <param name="token">The token to return</param>
+        public InMemoryCredentialStore(string token)
+        {
+            if (string.IsNullOrEmpty(token))
+            {
+                throw new ArgumentException(nameof(token));
+            }
+
+            this.token = token;
+        }
+
+        /// <inheritdoc />
         public Task<string> GetCredentials(CancellationToken cancellationToken = default) => Task.FromResult(token);
     }
 }

--- a/Octokit.GraphQL.Core/Internal/InMemoryCredentialStore.cs
+++ b/Octokit.GraphQL.Core/Internal/InMemoryCredentialStore.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
 namespace Octokit.GraphQL.Internal
 {
@@ -6,6 +7,6 @@ namespace Octokit.GraphQL.Internal
     {
         readonly string token;
         public InMemoryCredentialStore(string token) => this.token = token;
-        public Task<string> GetCredentials() => Task.FromResult(token);
+        public Task<string> GetCredentials(CancellationToken cancellationToken = default) => Task.FromResult(token);
     }
 }

--- a/Octokit.GraphQL.IntegrationTests/Configuration/HttpClientFactoryTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Configuration/HttpClientFactoryTests.cs
@@ -32,7 +32,7 @@ namespace Octokit.GraphQL.IntegrationTests.Configuration
 
             // Register a credential store so we can make a connection, as
             // well as a custom typed client that performs queries with Connections.
-            services.AddSingleton<ICredentialStore, InMemoryCredentialStore>((_) => new InMemoryCredentialStore(Helper.OAuthToken));
+            services.AddSingleton<ICredentialStore, InMemoryCredentialStore>((_) => new InMemoryCredentialStore(Helper.OAuthToken ?? " "));
             services.AddSingleton<MyQueryService>();
 
             // Register a typed HTTP client for use with the GitHub GraphQL API

--- a/Octokit.GraphQL.IntegrationTests/Configuration/HttpClientFactoryTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Configuration/HttpClientFactoryTests.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Octokit.GraphQL.IntegrationTests.Utilities;
+using Octokit.GraphQL.Internal;
+using Polly;
+using Polly.CircuitBreaker;
+using Xunit;
+using static Octokit.GraphQL.Variable;
+
+namespace Octokit.GraphQL.IntegrationTests.Configuration
+{
+    public static class HttpClientFactoryTests
+    {
+        [Fact]
+        public static async Task Can_Configure_With_HttpClient_Factory()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Create a Polly policy that is a pre-isolated circuit breaker that is guaranteed to fail
+            var policy = Policy.Handle<Exception>().CircuitBreakerAsync(1, TimeSpan.MaxValue);
+            policy.Isolate();
+
+            // Register Polly with DI and our pre-isolated circuit breaker
+            services
+                .AddPolicyRegistry()
+                .Add(policy.PolicyKey, policy.AsAsyncPolicy<HttpResponseMessage>());
+
+            // Register a typed HTTP client for use with the GitHub GraphQL API
+            // that also configures Polly usage when performing HTTP calls.
+            services
+                .AddHttpClient<Connection>("Octokit.GraphQL")
+                .ConfigureHttpClient((httpClient) =>
+                {
+                    // Apply user-configuration to HttpClient
+                    httpClient.BaseAddress = Connection.GithubApiUri;
+                    httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("OctokitTests", "1.2.3"));
+                    httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github.antiope-preview+json"));
+                    httpClient.Timeout = TimeSpan.FromSeconds(10);
+                })
+                .AddPolicyHandlerFromRegistry(policy.PolicyKey);
+
+            // Register a credential store so we can make a connection, as
+            // well as a custom typed client that performs queries with Connections.
+            services.AddSingleton(new InMemoryCredentialStore(Helper.OAuthToken) as ICredentialStore);
+            services.AddSingleton<MyQueryService>();
+
+            // Create the service provider for the registered services
+            using (var provider = services.BuildServiceProvider())
+            {
+                var service = provider.GetRequiredService<MyQueryService>();
+
+                // Act and Assert
+                await Assert.ThrowsAsync<IsolatedCircuitException>(
+                    () => service.GetRepositoryAsync(
+                        "octokit",
+                        "octokit.graphql.net",
+                        repo => new
+                        {
+                            repo.Id,
+                            repo.Name,
+                            repo.Owner.Login,
+                            repo.IsFork,
+                            repo.IsPrivate,
+                        }));
+            }
+        }
+
+        private sealed class MyQueryService
+        {
+            private readonly Connection _connection;
+
+            public MyQueryService(Connection connection)
+            {
+                _connection = connection;
+            }
+
+            public Task<T> GetRepositoryAsync<T>(string owner, string name, Expression<Func<Model.Repository, T>> selector)
+            {
+                var query = new Query()
+                    .RepositoryOwner(Var("owner"))
+                    .Repository(Var("name"))
+                    .Select(selector)
+                    .Compile();
+
+                var variables = new Dictionary<string, object>
+                {
+                    { "owner", owner },
+                    { "name", name },
+                };
+
+                return _connection.Run(query, variables);
+            }
+        }
+    }
+}

--- a/Octokit.GraphQL.IntegrationTests/Octokit.GraphQL.IntegrationTests.csproj
+++ b/Octokit.GraphQL.IntegrationTests/Octokit.GraphQL.IntegrationTests.csproj
@@ -6,6 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.1.1" />
     <PackageReference Include="Octokit" Version="0.29.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />


### PR DESCRIPTION
Adds a test showing a proof-of-concept for injection of `HttpClient` into `Connection` so that `IHttpClientFactory` can be used for scenarios such as ASP.NET Core 2.1+ applications.

Relates to #125.

Depends on:
- [x] #139 
- [x] #140