### PR TITLE
Fix NullReferenceException in tests

### DIFF
--- a/Octokit.GraphQL.Core/Core/Builders/ExpressionCompiler.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/ExpressionCompiler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Linq.Expressions;
+using System.Threading;
 
 namespace Octokit.GraphQL.Core.Builders
 {
@@ -17,7 +18,8 @@ namespace Octokit.GraphQL.Core.Builders
             {
                 if (sourceExpression == null)
                 {
-                    sourceExpression = new ConcurrentDictionary<object, Expression>();
+                    var candidate = new ConcurrentDictionary<object, Expression>();
+                    Interlocked.CompareExchange(ref sourceExpression, candidate, null);
                 }
 
                 sourceExpression[compiled] = expression;

--- a/Octokit.GraphQL.Core/Core/Builders/ExpressionCompiler.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/ExpressionCompiler.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
 using System.Linq.Expressions;
 
 namespace Octokit.GraphQL.Core.Builders
 {
     public static class ExpressionCompiler
     {
-        static Dictionary<object, Expression> sourceExpression;
+        static ConcurrentDictionary<object, Expression> sourceExpression;
 
         public static bool IsUnitTesting { get; set; }
 
@@ -18,10 +17,10 @@ namespace Octokit.GraphQL.Core.Builders
             {
                 if (sourceExpression == null)
                 {
-                    sourceExpression = new Dictionary<object, Expression>();
+                    sourceExpression = new ConcurrentDictionary<object, Expression>();
                 }
 
-                sourceExpression.Add(compiled, expression);
+                sourceExpression[compiled] = expression;
             }
 
             return compiled;


### PR DESCRIPTION
If multiple unit tests are running in parallel, it is possible for the `Add()` operation on the dictionary to throw a `NullReferenceException` internally and cause a test to fail.

Fix this by using `ConcurrentDictionary` instead.

Originally part of #131.