### PR TITLE
Update tests' target framework

### DIFF
--- a/Octokit.GraphQL.Core.Generation.UnitTests/Octokit.GraphQL.Core.Generation.UnitTests.csproj
+++ b/Octokit.GraphQL.Core.Generation.UnitTests/Octokit.GraphQL.Core.Generation.UnitTests.csproj
@@ -1,18 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Octokit.GraphQL.Core.Generation\Octokit.GraphQL.Core.Generation.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Octokit.GraphQL.Core.UnitTests/ExpressionRewiterTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/ExpressionRewiterTests.cs
@@ -81,7 +81,7 @@ namespace Octokit.GraphQL.Core.UnitTests
                 });
 
             Expression<Func<JObject, object>> expected = data =>
-                (IEnumerable)Rewritten.List.Select(
+                (IEnumerable<object>)Rewritten.List.Select(
                     data["data"]["licenses"],
                     x => new
                     {
@@ -109,12 +109,12 @@ namespace Octokit.GraphQL.Core.UnitTests
                 });
 
             Expression<Func<JObject, object>> expected = data =>
-                (IEnumerable) Rewritten.List.Select(
+                (IEnumerable<object>) Rewritten.List.Select(
                     data["data"]["licenses"],
                     x => new
                     {
                         Body = x["body"].ToObject<string>(),
-                        Items = (IEnumerable) Rewritten.List.Select(x["items"], i => new
+                        Items = (IDictionary<string, object>) Rewritten.List.Select(x["items"], i => new
                         {
                             Key = i["key"].ToObject<string>(),
                             Description = i["description"].ToObject<string>()
@@ -207,7 +207,7 @@ namespace Octokit.GraphQL.Core.UnitTests
                 });
 
             Expression<Func<JObject, object>> expected = data =>
-                (IEnumerable)Rewritten.List.Select(
+                (IEnumerable<object>)Rewritten.List.Select(
                     Rewritten.List.OfType(data["data"]["nodes"], "Issue"),
                     x => new
                     {

--- a/Octokit.GraphQL.Core.UnitTests/Octokit.GraphQL.Core.UnitTests.csproj
+++ b/Octokit.GraphQL.Core.UnitTests/Octokit.GraphQL.Core.UnitTests.csproj
@@ -1,18 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Octokit.GraphQL.Core\Octokit.GraphQL.Core.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/Octokit.GraphQL.Core.UnitTests/PartialEvaluationTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/PartialEvaluationTests.cs
@@ -179,7 +179,7 @@ namespace Octokit.GraphQL.Core.UnitTests
             var query = (SimpleQuery<float>)new QueryBuilder().Build(expression);
             var result = new ResponseDeserializer().Deserialize(query, data);
 
-            Assert.IsType(typeof(float), result);
+            Assert.IsType<float>(result);
             Assert.Equal(12, result);
         }
 

--- a/Octokit.GraphQL.IntegrationTests/Octokit.GraphQL.IntegrationTests.csproj
+++ b/Octokit.GraphQL.IntegrationTests/Octokit.GraphQL.IntegrationTests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>Octokit.GraphQL.IntegrationTests</AssemblyName>
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.1.1" />

--- a/Octokit.GraphQL.IntegrationTests/Octokit.GraphQL.IntegrationTests.csproj
+++ b/Octokit.GraphQL.IntegrationTests/Octokit.GraphQL.IntegrationTests.csproj
@@ -6,9 +6,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Octokit" Version="0.29.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Octokit.GraphQL.Core\Octokit.GraphQL.Core.csproj" />

--- a/Octokit.GraphQL.IntegrationTests/Octokit.GraphQL.IntegrationTests.csproj
+++ b/Octokit.GraphQL.IntegrationTests/Octokit.GraphQL.IntegrationTests.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Octokit" Version="0.29.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/Octokit.GraphQL.IntegrationTests/Queries/IssueTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/IssueTests.cs
@@ -187,7 +187,7 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
             var result = (await Connection.Run(query)).ToList();
 
             Assert.True(result.Count > 100);
-            Assert.True(result.Any(x => x.Comments.Count > 100));
+            Assert.Contains(result, x => x.Comments.Count > 100);
         }
 
         [IntegrationTest(Skip = "Querying unions like this no longer works")]
@@ -213,7 +213,7 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
                     UnsubscribedEventId = issueTimelineItem.UnsubscribedEvent.Id,
                 });
 
-            Assert.NotNull(Connection.Run(query).Result.Last().ClosedEventId);
+            Assert.NotEqual(default(ID), Connection.Run(query).Result.Last().ClosedEventId);
         }
 
         class ActorModel

--- a/Octokit.GraphQL.IntegrationTests/Queries/PullRequestTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/PullRequestTests.cs
@@ -22,7 +22,7 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
 
             var results = Enumerable.ToArray(Connection.Run(query).Result);
 
-            Assert.Equal(1, results.Length);
+            Assert.Single(results);
             Assert.Equal("MDY6Q29tbWl0NzUyODY3OTpkYWZhYjhhZjA0ODM5NDU1ODM4Y2QzZmRlMTFkMTM5MTc0MTYyZmFh", results[0].Id.Value);
             var expectedMessage = "Adding README, CONTRIBUTING, LICENSE\n\nWe plan to release this code under the MIT license so might as well get\nthe right things in place early.";
             Assert.Equal(expectedMessage, results[0].Message);
@@ -124,7 +124,7 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
             var result = await Connection.Run(query);
 
             Assert.True(result.Reviews.Count > 100);
-            Assert.True(result.Reviews.Any(x => x.Comments.Count > 100));
+            Assert.Contains(result.Reviews, x => x.Comments.Count > 100);
         }
     }
 }

--- a/Octokit.GraphQL.IntegrationTests/Utilities/IntegrationTestAttribute.cs
+++ b/Octokit.GraphQL.IntegrationTests/Utilities/IntegrationTestAttribute.cs
@@ -18,7 +18,7 @@ namespace Octokit.GraphQL.IntegrationTests.Utilities
         public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
         {
             return Helper.HasCredentials
-                ? new[] { new XunitTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod) }
+                ? new[] { new XunitTestCase(_diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), TestMethodDisplayOptions.None, testMethod) }
                 : Enumerable.Empty<IXunitTestCase>();
         }
     }

--- a/Octokit.GraphQL.UnitTests/Octokit.GraphQL.UnitTests.csproj
+++ b/Octokit.GraphQL.UnitTests/Octokit.GraphQL.UnitTests.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Octokit.GraphQL\Octokit.GraphQL.csproj" />

--- a/Octokit.GraphQL.UnitTests/ResponseDeserializerTests.cs
+++ b/Octokit.GraphQL.UnitTests/ResponseDeserializerTests.cs
@@ -50,8 +50,8 @@ namespace Octokit.GraphQL.UnitTests
             Assert.Equal("1234", result.Id.Value);
             Assert.Equal("Octokit.GraphQL.Core", result.Name);
             Assert.Equal("grokys", result.Owner.Login);
-            Assert.Equal(false, result.IsFork);
-            Assert.Equal(false, result.IsPrivate);
+            Assert.False(result.IsFork);
+            Assert.False(result.IsPrivate);
         }
 
 


### PR DESCRIPTION
Update the tests to target `netcoreapp2.1` as well as update the .NET Core test SDK and xunit NuGet package references.

The xunit upgrade creates some code analysis warnings as xunit now ships with code analyzers, so they have also been fixed.

Originally part of #131.