### PR TITLE
Pass-through CancellationTokens to connections

### DIFF
--- a/Octokit.GraphQL.Core.Generation/SchemaReader.cs
+++ b/Octokit.GraphQL.Core.Generation/SchemaReader.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Octokit.GraphQL.Core.Generation.Models;
 using Octokit.GraphQL.Core.Introspection;
 
@@ -131,7 +129,7 @@ namespace Octokit.GraphQL.Core.Generation
                     }).ToList()
                 });
 
-            return await connection.Run(query);
+            return await connection.Run(query).ConfigureAwait(false);
         }
     }
 }

--- a/Octokit.GraphQL.Core/ConnectionExtensions.cs
+++ b/Octokit.GraphQL.Core/ConnectionExtensions.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Octokit.GraphQL.Core;
 
@@ -9,25 +9,28 @@ namespace Octokit.GraphQL
     {
         public static Task<T> Run<T>(
             this IConnection connection,
-            IQueryableValue<T> expression)
+            IQueryableValue<T> expression,
+            CancellationToken cancellationToken = default)
         {
-            return connection.Run(expression.Compile());
+            return connection.Run(expression.Compile(), cancellationToken: cancellationToken);
         }
 
         public static Task<IEnumerable<T>> Run<T>(
             this IConnection connection,
-            IQueryableList<T> expression)
+            IQueryableList<T> expression,
+            CancellationToken cancellationToken = default)
         {
-            return connection.Run(expression.Compile());
+            return connection.Run(expression.Compile(), cancellationToken: cancellationToken);
         }
 
         public static async Task<T> Run<T>(
             this IConnection connection,
             ICompiledQuery<T> query,
-            Dictionary<string, object> variables = null)
+            Dictionary<string, object> variables = null,
+            CancellationToken cancellationToken = default)
         {
             var run = query.Start(connection, variables);
-            while (await run.RunPage()) { }
+            while (await run.RunPage(cancellationToken)) { }
             return run.Result;
         }
     }

--- a/Octokit.GraphQL.Core/ConnectionExtensions.cs
+++ b/Octokit.GraphQL.Core/ConnectionExtensions.cs
@@ -30,7 +30,7 @@ namespace Octokit.GraphQL
             CancellationToken cancellationToken = default)
         {
             var run = query.Start(connection, variables);
-            while (await run.RunPage(cancellationToken)) { }
+            while (await run.RunPage(cancellationToken).ConfigureAwait(false)) { }
             return run.Result;
         }
     }

--- a/Octokit.GraphQL.Core/Core/IQueryRunner.cs
+++ b/Octokit.GraphQL.Core/Core/IQueryRunner.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octokit.GraphQL.Core
@@ -16,8 +17,11 @@ namespace Octokit.GraphQL.Core
         /// <summary>
         /// Runs the next page of the query.
         /// </summary>
-        /// <returns></returns>
-        Task<bool> RunPage();
+        /// <param name="cancellationToken">The optional cancellation token to use.</param>
+        /// <returns>
+        /// A <see cref="Task{TResult}"/> that returns whether a page was returned.
+        /// </returns>
+        Task<bool> RunPage(CancellationToken cancellationToken = default);
     }
 
     /// <summary>

--- a/Octokit.GraphQL.Core/Core/PagedQuery.cs
+++ b/Octokit.GraphQL.Core/Core/PagedQuery.cs
@@ -100,7 +100,7 @@ namespace Octokit.GraphQL.Core
 
                     // This is the first run, so run the master page.
                     var master = owner.MasterQuery;
-                    var data = await connection.Run(master.GetPayload(Variables), cancellationToken);
+                    var data = await connection.Run(master.GetPayload(Variables), cancellationToken).ConfigureAwait(false);
                     var json = deserializer.Deserialize(data);
 
                     json.AddAnnotation(this);
@@ -135,7 +135,7 @@ namespace Octokit.GraphQL.Core
                     var runner = subqueryRunners.Peek();
 
                     // Run its next page and pop it from the active runners if finished.
-                    if (!await runner.RunPage(cancellationToken))
+                    if (!await runner.RunPage(cancellationToken).ConfigureAwait(false))
                     {
                         subqueryRunners.Pop();
                     }

--- a/Octokit.GraphQL.Core/Core/PagedQuery.cs
+++ b/Octokit.GraphQL.Core/Core/PagedQuery.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Octokit.GraphQL.Core.Deserializers;
 
@@ -82,11 +82,16 @@ namespace Octokit.GraphQL.Core
                 this.Variables = variables;
             }
 
+            /// <inheritdoc />
             public TResult Result { get; private set; }
+
+            /// <inheritdoc />
             object IQueryRunner.Result => Result;
+
             protected IDictionary<string, object> Variables { get; }
 
-            public virtual async Task<bool> RunPage()
+            /// <inheritdoc />
+            public virtual async Task<bool> RunPage(CancellationToken cancellationToken = default)
             {
                 if (subqueryRunners == null)
                 {
@@ -95,7 +100,7 @@ namespace Octokit.GraphQL.Core
 
                     // This is the first run, so run the master page.
                     var master = owner.MasterQuery;
-                    var data = await connection.Run(master.GetPayload(Variables));
+                    var data = await connection.Run(master.GetPayload(Variables), cancellationToken);
                     var json = deserializer.Deserialize(data);
 
                     json.AddAnnotation(this);
@@ -130,7 +135,7 @@ namespace Octokit.GraphQL.Core
                     var runner = subqueryRunners.Peek();
 
                     // Run its next page and pop it from the active runners if finished.
-                    if (!await runner.RunPage())
+                    if (!await runner.RunPage(cancellationToken))
                     {
                         subqueryRunners.Pop();
                     }

--- a/Octokit.GraphQL.Core/Core/PagedSubquery.cs
+++ b/Octokit.GraphQL.Core/Core/PagedSubquery.cs
@@ -4,10 +4,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Octokit.GraphQL.Core.Builders;
-using Octokit.GraphQL.Core.Deserializers;
 
 namespace Octokit.GraphQL.Core
 {
@@ -122,9 +122,10 @@ namespace Octokit.GraphQL.Core
                 this.addResult = addResult;
             }
 
-            public override async Task<bool> RunPage()
+            /// <inheritdoc/>
+            public override async Task<bool> RunPage(CancellationToken cancellationToken = default)
             {
-                var more = await base.RunPage();
+                var more = await base.RunPage(cancellationToken);
 
                 if (!more)
                 {

--- a/Octokit.GraphQL.Core/Core/PagedSubquery.cs
+++ b/Octokit.GraphQL.Core/Core/PagedSubquery.cs
@@ -125,7 +125,7 @@ namespace Octokit.GraphQL.Core
             /// <inheritdoc/>
             public override async Task<bool> RunPage(CancellationToken cancellationToken = default)
             {
-                var more = await base.RunPage(cancellationToken);
+                var more = await base.RunPage(cancellationToken).ConfigureAwait(false);
 
                 if (!more)
                 {

--- a/Octokit.GraphQL.Core/Core/SimpleQuery.cs
+++ b/Octokit.GraphQL.Core/Core/SimpleQuery.cs
@@ -122,7 +122,7 @@ namespace Octokit.GraphQL.Core
             public async Task<bool> RunPage(CancellationToken cancellationToken = default)
             {
                 var deserializer = new ResponseDeserializer();
-                var data = await connection.Run(parent.GetPayload(variables), cancellationToken);
+                var data = await connection.Run(parent.GetPayload(variables), cancellationToken).ConfigureAwait(false);
                 Result = deserializer.Deserialize(parent.ResultBuilder, data);
                 return false;
             }

--- a/Octokit.GraphQL.Core/Core/SimpleQuery.cs
+++ b/Octokit.GraphQL.Core/Core/SimpleQuery.cs
@@ -1,14 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using Octokit.GraphQL.Core.Serializers;
-using Octokit.GraphQL.Core.Syntax;
+using System.Threading;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
-using System.Threading.Tasks;
 using Octokit.GraphQL.Core.Builders;
 using Octokit.GraphQL.Core.Deserializers;
+using Octokit.GraphQL.Core.Serializers;
+using Octokit.GraphQL.Core.Syntax;
 
 namespace Octokit.GraphQL.Core
 {
@@ -111,13 +112,17 @@ namespace Octokit.GraphQL.Core
                 this.variables = variables;
             }
 
+            /// <inheritdoc />
             public TResult Result { get; private set; }
+
+            /// <inheritdoc />
             object IQueryRunner.Result => Result;
 
-            public async Task<bool> RunPage()
+            /// <inheritdoc />
+            public async Task<bool> RunPage(CancellationToken cancellationToken = default)
             {
                 var deserializer = new ResponseDeserializer();
-                var data = await connection.Run(parent.GetPayload(variables));
+                var data = await connection.Run(parent.GetPayload(variables), cancellationToken);
                 Result = deserializer.Deserialize(parent.ResultBuilder, data);
                 return false;
             }

--- a/Octokit.GraphQL.Core/Core/SimpleSubquery.cs
+++ b/Octokit.GraphQL.Core/Core/SimpleSubquery.cs
@@ -137,7 +137,7 @@ namespace Octokit.GraphQL.Core
             public async Task<bool> RunPage(CancellationToken cancellationToken = default)
             {
                 var payload = owner.GetPayload(variables);
-                var data = await connection.Run(payload, cancellationToken);
+                var data = await connection.Run(payload, cancellationToken).ConfigureAwait(false);
                 var json = deserializer.Deserialize(data);
                 var pageInfo = owner.PageInfo(json);
 

--- a/Octokit.GraphQL.Core/Core/SimpleSubquery.cs
+++ b/Octokit.GraphQL.Core/Core/SimpleSubquery.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Octokit.GraphQL.Core.Builders;
@@ -126,14 +127,17 @@ namespace Octokit.GraphQL.Core
                 this.addResult = addResult;
             }
 
+            /// <inheritdoc />
             public TResult Result { get; private set; }
 
+            /// <inheritdoc />
             object IQueryRunner.Result => Result;
 
-            public async Task<bool> RunPage()
+            /// <inheritdoc />
+            public async Task<bool> RunPage(CancellationToken cancellationToken = default)
             {
                 var payload = owner.GetPayload(variables);
-                var data = await connection.Run(payload);
+                var data = await connection.Run(payload, cancellationToken);
                 var json = deserializer.Deserialize(data);
                 var pageInfo = owner.PageInfo(json);
 


### PR DESCRIPTION
This PR add some optional parameters to some methods so that `CancellationToken`s can be passed through to [`IConnection.Run()`](https://github.com/octokit/octokit.graphql.net/blob/a438be61666dba11ee9964c7375e787666c7766a/Octokit.GraphQL.Core/IConnection.cs#L25) ([original PR comment](https://github.com/octokit/octokit.graphql.net/pull/131#issuecomment-411849604)).

It also adds `ConfigureAwait(false)` calls to usages of `await` inside the library and few liberal sprinkles of `/// <inheritdoc />` where relevant in files I touched.