### PR TITLE
Initial support for unions

### DIFF
--- a/Octokit.GraphQL.Core.UnitTests/Models/Commit.cs
+++ b/Octokit.GraphQL.Core.UnitTests/Models/Commit.cs
@@ -1,0 +1,17 @@
+using System.Linq.Expressions;
+
+namespace Octokit.GraphQL.Core.UnitTests.Models
+{
+    public class Commit : QueryableValue<Commit>
+    {
+        public Commit(Expression expression) : base(expression)
+        {
+        }
+        public string AbbreviatedOid { get; }
+
+        internal static Commit Create(Expression expression)
+        {
+            return new Commit(expression);
+        }
+    }
+}

--- a/Octokit.GraphQL.Core.UnitTests/Models/IssueOrPullRequest.cs
+++ b/Octokit.GraphQL.Core.UnitTests/Models/IssueOrPullRequest.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Linq.Expressions;
+using Octokit.GraphQL.Core.Builders;
+
+namespace Octokit.GraphQL.Core.UnitTests.Models
+{
+    public class IssueOrPullRequest : QueryableValue<IssueOrPullRequest>, IUnion
+    {
+        public IssueOrPullRequest(Expression expression) : base(expression)
+        {
+        }
+
+        public TResult Switch<TResult>(Expression<Func<Selector<TResult>, Selector<TResult>>> select) => default;
+
+        public class Selector<T>
+        {
+            public Selector<T> Issue(Func<Issue, T> selector) => default;
+            public Selector<T> PullRequest(Func<PullRequest, T> selector) => default;
+        }
+
+        internal static IssueOrPullRequest Create(Expression expression)
+        {
+            return new IssueOrPullRequest(expression);
+        }
+    }
+}

--- a/Octokit.GraphQL.Core.UnitTests/Models/PullRequest.cs
+++ b/Octokit.GraphQL.Core.UnitTests/Models/PullRequest.cs
@@ -1,0 +1,22 @@
+using System.Linq.Expressions;
+using Octokit.GraphQL.Core.Builders;
+
+namespace Octokit.GraphQL.Core.UnitTests.Models
+{
+    public class PullRequest : QueryableValue<PullRequest>
+    {
+        public PullRequest(Expression expression) : base(expression)
+        {
+        }
+
+        public string Body { get; }
+        public int Number { get; }
+        public string Title { get; }
+        public PullRequestTimelineConnection Timeline(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Timeline(first, after, last, before), Models.PullRequestTimelineConnection.Create);
+
+        internal static PullRequest Create(Expression expression)
+        {
+            return new PullRequest(expression);
+        }
+    }
+}

--- a/Octokit.GraphQL.Core.UnitTests/Models/PullRequestTimelineConnection.cs
+++ b/Octokit.GraphQL.Core.UnitTests/Models/PullRequestTimelineConnection.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Octokit.GraphQL.Core;
+using Octokit.GraphQL.Core.Builders;
+
+namespace Octokit.GraphQL.Core.UnitTests.Models
+{
+    public class PullRequestTimelineConnection : QueryableValue<PullRequestTimelineConnection>, IPagingConnection<PullRequestTimelineItem>
+    {
+        public PullRequestTimelineConnection(Expression expression) : base(expression)
+        {
+        }
+
+        public IQueryableList<PullRequestTimelineItem> Nodes => this.CreateProperty(x => x.Nodes);
+        public PageInfo PageInfo => this.CreateProperty(x => x.PageInfo, Models.PageInfo.Create);
+        public int TotalCount { get; }
+        IPageInfo IPagingConnection.PageInfo => PageInfo;
+
+        internal static PullRequestTimelineConnection Create(Expression expression)
+        {
+            return new PullRequestTimelineConnection(expression);
+        }
+    }
+}

--- a/Octokit.GraphQL.Core.UnitTests/Models/PullRequestTimelineItem.cs
+++ b/Octokit.GraphQL.Core.UnitTests/Models/PullRequestTimelineItem.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq.Expressions;
+
+namespace Octokit.GraphQL.Core.UnitTests.Models
+{
+    public class PullRequestTimelineItem : QueryableValue<PullRequestTimelineItem>, IUnion
+    {
+        public PullRequestTimelineItem(Expression expression) : base(expression)
+        {
+        }
+
+        public TResult Switch<TResult>(Func<Selector<TResult>, Selector<TResult>> select) => default;
+
+        public class Selector<T>
+        {
+            public Selector<T> Commit(Func<Commit, T> selector) => default;
+            public Selector<T> IssueComment(Func<IssueComment, T> selector) => default;
+        }
+
+        internal static PullRequestTimelineItem Create(Expression expression)
+        {
+            return new PullRequestTimelineItem(expression);
+        }
+    }
+}

--- a/Octokit.GraphQL.Core.UnitTests/Models/Repository.cs
+++ b/Octokit.GraphQL.Core.UnitTests/Models/Repository.cs
@@ -20,7 +20,9 @@ namespace Octokit.GraphQL.Core.UnitTests.Models
         public ID Id { get; }
         public string Name { get; }
         public Issue Issue(Arg<int> number) => this.CreateMethodCall(x => x.Issue(number), Models.Issue.Create);
+        public IssueOrPullRequest IssueOrPullRequest(Arg<int> number) => this.CreateMethodCall(x => x.IssueOrPullRequest(number), Models.IssueOrPullRequest.Create);
         public IssueConnection Issues(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<IEnumerable<string>>? labels = null) => this.CreateMethodCall(x => x.Issues(first, after, last, before, labels), IssueConnection.Create);
+        public PullRequest PullRequest(Arg<int> number) => this.CreateMethodCall(x => x.PullRequest(number), Models.PullRequest.Create);
 
         internal static Repository Create(Expression expression)
         {

--- a/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
@@ -362,16 +362,7 @@ namespace Octokit.GraphQL.Core.Builders
 
         private Expression VisitMember(MemberExpression node, MemberInfo alias)
         {
-            if (IsUnionMember(node.Member))
-            {
-                var source = Visit(node.Expression);
-                var fragment = syntax.AddInlineFragment(((PropertyInfo)node.Member).PropertyType, true);
-                return Expression.Call(
-                    Rewritten.Value.OfTypeMethod,
-                    source,
-                    Expression.Constant(fragment.TypeCondition.Name));
-            }
-            else if (IsQueryableValueMember(node.Member))
+            if (IsQueryableValueMember(node.Member))
             {
                 var expression = node.Expression;
                 bool isSubqueryPager = false;
@@ -506,6 +497,10 @@ namespace Octokit.GraphQL.Core.Builders
             else if (node.Method.DeclaringType == typeof(PagingConnectionExtensions))
             {
                 return RewritePagingConnectionExtensions(node);
+            }
+            else if (IsUnionSwitch(node.Method))
+            {
+                return RewriteUnionSwitch(node);
             }
             else if (IsQueryableValueMember(node.Method))
             {
@@ -674,7 +669,7 @@ namespace Octokit.GraphQL.Core.Builders
                     syntax.AddField("nodes");
                     instance = instance.AddIndexer("nodes");
                 }
-                
+
                 var select = (LambdaExpression)Visit(lambda);
                 var rewrittenSelect = Expression.Call(
                     Rewritten.List.SelectMethod.MakeGenericMethod(select.ReturnType),
@@ -913,6 +908,52 @@ namespace Octokit.GraphQL.Core.Builders
             else
             {
                 throw new NotSupportedException($"{expression.Method.Name}() is not supported");
+            }
+        }
+
+        private Expression RewriteUnionSwitch(MethodCallExpression expression)
+        {
+            var source = expression.Object;
+            var instance = Visit(source);
+            var resultType = expression.Method.GetGenericArguments()[0];
+
+            if (!(expression.Arguments[0].GetLambda().Body is MethodCallExpression casesBody))
+            {
+                throw new GraphQLException("Expected union switch expression.");
+            }
+
+            var cases = new Dictionary<string, Expression>();
+            BuildUnionSwitchCases(casesBody, cases);
+
+            var funcType = typeof(Func<,>).MakeGenericType(typeof(JToken), resultType);
+            var dictionaryType = typeof(Dictionary<,>).MakeGenericType(typeof(string), funcType);
+            var dictionaryAdd = dictionaryType.GetTypeInfo().GetDeclaredMethod("Add");
+            var newDictionary = Expression.ListInit(
+                Expression.New(dictionaryType),
+                cases.Select(x => Expression.ElementInit(dictionaryAdd, Expression.Constant(x.Key), x.Value)));
+
+            return Expression.Call(
+                Rewritten.Value.SwitchMethod.MakeGenericMethod(resultType),
+                instance,
+                newDictionary);
+            throw new NotImplementedException();
+        }
+
+        private void BuildUnionSwitchCases(MethodCallExpression body, Dictionary<string, Expression> result)
+        {
+            if (body.Object is MethodCallExpression previous)
+            {
+                BuildUnionSwitchCases(previous, result);
+            }
+
+            using (syntax.Bookmark())
+            {
+                var methodParam = body.Method.GetParameters()[0];
+                var type = methodParam.ParameterType.GenericTypeArguments[0];
+                syntax.AddInlineFragment(type, true);
+
+                var selector = Visit(body.Arguments[0]);
+                result.Add(type.Name, selector);
             }
         }
 
@@ -1211,9 +1252,11 @@ namespace Octokit.GraphQL.Core.Builders
             return typeof(IUnion).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo());
         }
 
-        private static bool IsUnionMember(MemberInfo member)
+        private static bool IsUnionSwitch(MemberInfo member)
         {
-            return member is PropertyInfo && IsUnion(member.DeclaringType);
+            return IsUnion(member.DeclaringType) &&
+                member is MethodInfo m &&
+                m.Name == "Switch";
         }
 
         private static FieldSelection PageInfoSelection()

--- a/Octokit.GraphQL.Core/Core/Builders/QueryEntityBuilders.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/QueryEntityBuilders.cs
@@ -29,6 +29,28 @@ namespace Octokit.GraphQL.Core.Builders
                     arguments));
         }
 
+        public static IQueryableValue<TValue> CreateMethodCall<TObject, TValue>(
+            this TObject o,
+            Expression<Func<TObject, IQueryableValue<TValue>>> selector)
+                where TObject : IQueryableValue
+        {
+            var methodCall = (MethodCallExpression)selector.Body;
+            var arguments = new List<ConstantExpression>();
+
+            foreach (MemberExpression arg in methodCall.Arguments)
+            {
+                var expression = (ConstantExpression)arg.Expression;
+                var value = ((FieldInfo)arg.Member).GetValue(expression.Value);
+                arguments.Add(Expression.Constant(value, arg.Type));
+            }
+
+            return new QueryableValue<TValue>(
+                Expression.Call(
+                    Expression.Constant(o),
+                    methodCall.Method,
+                    arguments));
+        }
+
         public static TValue CreateMethodCall<TObject, TValue>(
             this TObject o,
             Expression<Func<TObject, TValue>> selector,

--- a/Octokit.GraphQL.Core/Core/Builders/Rewritten.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/Rewritten.cs
@@ -16,6 +16,7 @@ namespace Octokit.GraphQL.Core.Builders
             public static readonly MethodInfo SelectListMethod = typeof(Value).GetTypeInfo().GetDeclaredMethod(nameof(SelectList));
             public static readonly MethodInfo SingleMethod = typeof(Value).GetTypeInfo().GetDeclaredMethod(nameof(Single));
             public static readonly MethodInfo SingleOrDefaultMethod = typeof(Value).GetTypeInfo().GetDeclaredMethod(nameof(SingleOrDefault));
+            public static readonly MethodInfo SwitchMethod = typeof(Value).GetTypeInfo().GetDeclaredMethod(nameof(Switch));
 
             public static JToken OfType(JToken source, string typeName)
             {
@@ -48,6 +49,18 @@ namespace Octokit.GraphQL.Core.Builders
             }
 
             public static TResult SingleOrDefault<TResult>(TResult value) => value;
+
+            public static TResult Switch<TResult>(JToken source, IDictionary<string, Func<JToken, TResult>> selectors)
+            {
+                var typename = (string)source["__typename"];
+
+                if (selectors.TryGetValue(typename, out var selector))
+                {
+                    return selector(source);
+                }
+
+                return default;
+            }
         }
 
         public static class List

--- a/Octokit.GraphQL.Core/Core/Syntax/SyntaxTree.cs
+++ b/Octokit.GraphQL.Core/Core/Syntax/SyntaxTree.cs
@@ -55,7 +55,7 @@ namespace Octokit.GraphQL.Core.Syntax
 
             if (selectTypeName)
             {
-                Head.Selections.Add(new FieldSelection("__typename", null));
+                AddField(Head, new FieldSelection("__typename", null), false);
             }
 
             Head.Selections.Add(result);
@@ -97,7 +97,7 @@ namespace Octokit.GraphQL.Core.Syntax
             });
         }
 
-        private FieldSelection AddField(ISelectionSet parent, FieldSelection field)
+        private FieldSelection AddField(ISelectionSet parent, FieldSelection field, bool updateHead = true)
         {
             var existing = field.Alias == null ?
                 parent.Selections
@@ -114,8 +114,12 @@ namespace Octokit.GraphQL.Core.Syntax
                 field = existing;
             }
 
-            Head = field;
-            FieldStack.Add(field);
+            if (updateHead)
+            {
+                Head = field;
+                FieldStack.Add(field);
+            }
+
             return field;
         }
     }

--- a/Octokit.GraphQL.IntegrationTests/Octokit.GraphQL.IntegrationTests.v3.ncrunchproject
+++ b/Octokit.GraphQL.IntegrationTests/Octokit.GraphQL.IntegrationTests.v3.ncrunchproject
@@ -1,5 +1,25 @@
 ﻿<ProjectConfiguration>
   <Settings>
+    <IgnoredTests>
+      <NamedTestSelector>
+        <TestName>Octokit.GraphQL.IntegrationTests.Mutations.MutationTests.Create_And_Delete_Project</TestName>
+      </NamedTestSelector>
+      <NamedTestSelector>
+        <TestName>Octokit.GraphQL.IntegrationTests.Mutations.MutationTests.Star_And_Unstar_Project</TestName>
+      </NamedTestSelector>
+      <NamedTestSelector>
+        <TestName>Octokit.GraphQL.IntegrationTests.Queries.RepositoryTests.Query_Organization_Repositories_Select_Multiple_Object_Fragments</TestName>
+      </NamedTestSelector>
+      <NamedTestSelector>
+        <TestName>Octokit.GraphQL.IntegrationTests.Queries.RepositoryTests.Should_Query_Repository_Issues_PullRequests_To_Object_AutoPaging</TestName>
+      </NamedTestSelector>
+      <NamedTestSelector>
+        <TestName>Octokit.GraphQL.IntegrationTests.Queries.RepositoryTests.Should_Query_Repository_Issues_PullRequests_With_Variables_AutoPaging</TestName>
+      </NamedTestSelector>
+      <NamedTestSelector>
+        <TestName>Octokit.GraphQL.IntegrationTests.Queries.ViewerTests.Viewer_By_GraphyQL_Matches_Api</TestName>
+      </NamedTestSelector>
+    </IgnoredTests>
     <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
   </Settings>
 </ProjectConfiguration>

--- a/Octokit.GraphQL.IntegrationTests/Queries/IssueTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/IssueTests.cs
@@ -197,34 +197,6 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
             Assert.Contains(result, x => x.Comments.Count > 100);
         }
 
-        [IntegrationTest(Skip = "Querying unions like this no longer works")]
-        public async Task Should_Query_Union_Issue_Or_PullRequest2()
-        {
-            var query = new Query().Repository("octokit", "octokit.net").Issue(23)
-                .Timeline(first: 30).Nodes
-                .Select(issueTimelineItem => new
-                {
-                    AssignedEventId = issueTimelineItem.AssignedEvent.Id,
-                    ClosedEventId = issueTimelineItem.ClosedEvent.Id,
-                    DemilestonedEventId = issueTimelineItem.DemilestonedEvent.Id,
-                    LabeledEventId = issueTimelineItem.LabeledEvent.Id,
-                    LockedEventId = issueTimelineItem.LockedEvent.Id,
-                    MilestonedEventId = issueTimelineItem.MilestonedEvent.Id,
-                    ReferencedEventId = issueTimelineItem.ReferencedEvent.Id,
-                    RenamedTitleEventId = issueTimelineItem.RenamedTitleEvent.Id,
-                    ReopenedEventId = issueTimelineItem.ReopenedEvent.Id,
-                    SubscribedEventId = issueTimelineItem.SubscribedEvent.Id,
-                    UnassignedEventId = issueTimelineItem.UnassignedEvent.Id,
-                    UnlabeledEventId = issueTimelineItem.UnlabeledEvent.Id,
-                    UnlockedEventId = issueTimelineItem.UnlockedEvent.Id,
-                    UnsubscribedEventId = issueTimelineItem.UnsubscribedEvent.Id,
-                });
-
-            var result = (await Connection.Run(query)).Last();
-
-            Assert.NotEqual(default(ID), result.ClosedEventId);
-        }
-
         class ActorModel
         {
             public string Login { get; set; }

--- a/Octokit.GraphQL.IntegrationTests/Queries/PullRequestTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/PullRequestTests.cs
@@ -136,7 +136,7 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
         public async Task PullRequest_Status_Context_CanBeNull()
         {
             var query = new Query()
-            .Repository("StanleyGoldman", "ConsoleCoreAppWithYamlForNoReason")
+            .Repository(owner: "StanleyGoldman", name: "ConsoleCoreAppWithYamlForNoReason")
             .PullRequests(1)
             .Select(page => 
                 page.Nodes.Select(pr => new 

--- a/Octokit.GraphQL.IntegrationTests/Queries/RepositoryTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/RepositoryTests.cs
@@ -335,19 +335,19 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
             Assert.True(result.StringList2.Count > 500);
         }
 
-        [IntegrationTest(Skip = "Querying unions like this no longer works")]
+        [IntegrationTest]
         public async Task Should_Query_Union_Issue_Or_PullRequest()
         {
             var query = new Query()
                 .Repository(owner: "octokit", name: "octokit.net")
                 .IssueOrPullRequest(number: 1)
-                .Select(issueOrPullRequest => new
-                {
-                    IssueId = issueOrPullRequest.Issue.Id,
-                    PullRequestId = issueOrPullRequest.PullRequest.Id
-                });
+                .Select(issueOrPullRequest => issueOrPullRequest.Switch<string>(when =>
+                    when.Issue(issue => "Issue " + issue.Number)
+                        .PullRequest(pr => "PR " + pr.Number)));
 
             var result = await Connection.Run(query);
+
+            Assert.Equal("PR 1", result);
         }
 
         class TestModelObject

--- a/Octokit.GraphQL.IntegrationTests/Queries/RepositoryTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/RepositoryTests.cs
@@ -381,7 +381,6 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
             Assert.NotNull(result.repoOwner);
         }
 
-        [IntegrationTest(Skip = "Querying unions like this no longer works")]
         [IntegrationTest]
         public async Task Should_Query_Union_Issue_Or_PullRequest()
         {
@@ -400,7 +399,8 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
         [IntegrationTest]
         public void Should_Handle_Null_Repository_Parent_Using_SingleOrDefault()
         {
-            var query = new Query().Repository("octokit", "octokit.net")
+            var query = new Query()
+                .Repository(owner: "octokit", name: "octokit.net")
                 .Select(repository => new
                 {
                     Name = repository.Name,
@@ -417,7 +417,8 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
         [IntegrationTest]
         public void Should_Handle_Null_Repository_ParentName_Using_SingleOrDefault()
         {
-            var query = new Query().Repository("octokit", "octokit.net")
+            var query = new Query()
+                .Repository(owner: "octokit", name: "octokit.net")
                 .Select(repository => new
                 {
                     Name = repository.Name,

--- a/Octokit.GraphQL.IntegrationTests/SearchTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/SearchTests.cs
@@ -12,7 +12,11 @@ namespace Octokit.GraphQL.IntegrationTests
         [IntegrationTest]
         public void Should_Query_Commits()
         {
-            var query = new Query().Search("language:JavaScript stars:>10000", SearchType.Issue, first: 3).Nodes.Select(searchResultItem => new {searchResultItem.Issue.Id});
+            var query = new Query()
+                .Search("language:JavaScript stars:>10000", SearchType.Issue, first: 3)
+                .Nodes
+                .Select(item => item.Switch<string>(when =>
+                    when.Issue(issue => issue.Id.Value)));
 
             var queryBuilder = new QueryBuilder();
             var queryString = queryBuilder.Build(query);;

--- a/Octokit.GraphQL.UnitTests/ExpressionRewiterTests.cs
+++ b/Octokit.GraphQL.UnitTests/ExpressionRewiterTests.cs
@@ -203,10 +203,12 @@ namespace Octokit.GraphQL.UnitTests
                     when.User(user => user.Name)));
 
             Expression<Func<JObject, IEnumerable<string>>> expected = data =>
-                (IEnumerable<string>)
-                Rewritten.List.Select(
+                (IEnumerable<string>)Rewritten.List.Select(
                     Rewritten.List.Select(data["data"]["search"]["edges"], x => x["node"]),
-                    x => Rewritten.Value.OfType(x, "User")["name"].ToObject<string>()).ToList();
+                    x => Rewritten.Value.Switch(x, new Dictionary<string, Func<JToken, string>>
+                    {
+                        { "User", user => user["name"].ToObject<string>() },
+                    })).ToList();
 
             ExpressionRewriterAssertions.AssertExpressionQueryEqual(expected, query);
         }

--- a/Octokit.GraphQL.UnitTests/ExpressionRewiterTests.cs
+++ b/Octokit.GraphQL.UnitTests/ExpressionRewiterTests.cs
@@ -199,7 +199,8 @@ namespace Octokit.GraphQL.UnitTests
             var query = new Query()
                 .Search("foo", SearchType.User, 30)
                 .Edges.Select(x => x.Node)
-                .Select(x => x.User.Name);
+                .Select(x => x.Switch<string>(when =>
+                    when.User(user => user.Name)));
 
             Expression<Func<JObject, IEnumerable<string>>> expected = data =>
                 (IEnumerable<string>)

--- a/Octokit.GraphQL.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.UnitTests/QueryBuilderTests.cs
@@ -253,7 +253,8 @@ namespace Octokit.GraphQL.UnitTests
             var expression = new Query()
                 .Search("foo", SearchType.User, 30)
                 .Nodes
-                .Select(x => x.User.Name);
+                .Select(x => x.Switch<string>(when =>
+                    when.User(user => user.Name)));
 
             var query = expression.Compile();
 
@@ -278,12 +279,12 @@ namespace Octokit.GraphQL.UnitTests
             var expression = new Query()
                 .Search("foo", SearchType.User, 30)
                 .Nodes
-                .Select(x => x.User)
-                .Select(x => new
-                {
-                    x.Name,
-                    x.Login,
-                });
+                .Select(x => x.Switch<object>(when =>
+                    when.User(user => new
+                    {
+                        user.Name,
+                        user.Login,
+                    })));
 
             var query = expression.Compile();
 
@@ -309,7 +310,8 @@ namespace Octokit.GraphQL.UnitTests
             var expression = new Query()
                 .Search("foo", SearchType.User, 30)
                 .Edges.Select(x => x.Node)
-                .Select(x => x.User.Name);
+                .Select(x => x.Switch<string>(when =>
+                    when.User(user => user.Name)));
 
             var query = expression.Compile();
 

--- a/Octokit.GraphQL/Model/Closer.cs
+++ b/Octokit.GraphQL/Model/Closer.cs
@@ -1,5 +1,6 @@
 namespace Octokit.GraphQL.Model
 {
+    using System;
     using System.Linq;
     using System.Linq.Expressions;
     using Octokit.GraphQL.Core;
@@ -14,15 +15,20 @@ namespace Octokit.GraphQL.Model
         {
         }
 
-        /// <summary>
-        /// Represents a Git commit.
-        /// </summary>
-        public Commit Commit => this.CreateProperty(x => x.Commit, Octokit.GraphQL.Model.Commit.Create);
+        public TResult Switch<TResult>(Expression<Func<Selector<TResult>, Selector<TResult>>> select) => default;
 
-        /// <summary>
-        /// A repository pull request.
-        /// </summary>
-        public PullRequest PullRequest => this.CreateProperty(x => x.PullRequest, Octokit.GraphQL.Model.PullRequest.Create);
+        public class Selector<T>
+        {
+            /// <summary>
+            /// Represents a Git commit.
+            /// </summary>
+            public Selector<T> Commit(Func<Commit, T> selector) => default;
+
+            /// <summary>
+            /// A repository pull request.
+            /// </summary>
+            public Selector<T> PullRequest(Func<PullRequest, T> selector) => default;
+        }
 
         internal static Closer Create(Expression expression)
         {

--- a/Octokit.GraphQL/Model/CollectionItemContent.cs
+++ b/Octokit.GraphQL/Model/CollectionItemContent.cs
@@ -1,5 +1,6 @@
 namespace Octokit.GraphQL.Model
 {
+    using System;
     using System.Linq;
     using System.Linq.Expressions;
     using Octokit.GraphQL.Core;
@@ -14,20 +15,25 @@ namespace Octokit.GraphQL.Model
         {
         }
 
-        /// <summary>
-        /// A repository contains the content for a project.
-        /// </summary>
-        public Repository Repository => this.CreateProperty(x => x.Repository, Octokit.GraphQL.Model.Repository.Create);
+        public TResult Switch<TResult>(Expression<Func<Selector<TResult>, Selector<TResult>>> select) => default;
 
-        /// <summary>
-        /// An account on GitHub, with one or more owners, that has repositories, members and teams.
-        /// </summary>
-        public Organization Organization => this.CreateProperty(x => x.Organization, Octokit.GraphQL.Model.Organization.Create);
+        public class Selector<T>
+        {
+            /// <summary>
+            /// A repository contains the content for a project.
+            /// </summary>
+            public Selector<T> Repository(Func<Repository, T> selector) => default;
 
-        /// <summary>
-        /// A user is an individual's account on GitHub that owns repositories and can make new content.
-        /// </summary>
-        public User User => this.CreateProperty(x => x.User, Octokit.GraphQL.Model.User.Create);
+            /// <summary>
+            /// An account on GitHub, with one or more owners, that has repositories, members and teams.
+            /// </summary>
+            public Selector<T> Organization(Func<Organization, T> selector) => default;
+
+            /// <summary>
+            /// A user is an individual's account on GitHub that owns repositories and can make new content.
+            /// </summary>
+            public Selector<T> User(Func<User, T> selector) => default;
+        }
 
         internal static CollectionItemContent Create(Expression expression)
         {

--- a/Octokit.GraphQL/Model/IssueOrPullRequest.cs
+++ b/Octokit.GraphQL/Model/IssueOrPullRequest.cs
@@ -1,5 +1,6 @@
 namespace Octokit.GraphQL.Model
 {
+    using System;
     using System.Linq;
     using System.Linq.Expressions;
     using Octokit.GraphQL.Core;
@@ -14,15 +15,20 @@ namespace Octokit.GraphQL.Model
         {
         }
 
-        /// <summary>
-        /// An Issue is a place to discuss ideas, enhancements, tasks, and bugs for a project.
-        /// </summary>
-        public Issue Issue => this.CreateProperty(x => x.Issue, Octokit.GraphQL.Model.Issue.Create);
+        public TResult Switch<TResult>(Expression<Func<Selector<TResult>, Selector<TResult>>> select) => default;
 
-        /// <summary>
-        /// A repository pull request.
-        /// </summary>
-        public PullRequest PullRequest => this.CreateProperty(x => x.PullRequest, Octokit.GraphQL.Model.PullRequest.Create);
+        public class Selector<T>
+        {
+            /// <summary>
+            /// An Issue is a place to discuss ideas, enhancements, tasks, and bugs for a project.
+            /// </summary>
+            public Selector<T> Issue(Func<Issue, T> selector) => default;
+
+            /// <summary>
+            /// A repository pull request.
+            /// </summary>
+            public Selector<T> PullRequest(Func<PullRequest, T> selector) => default;
+        }
 
         internal static IssueOrPullRequest Create(Expression expression)
         {

--- a/Octokit.GraphQL/Model/IssueTimelineItem.cs
+++ b/Octokit.GraphQL/Model/IssueTimelineItem.cs
@@ -1,5 +1,6 @@
 namespace Octokit.GraphQL.Model
 {
+    using System;
     using System.Linq;
     using System.Linq.Expressions;
     using Octokit.GraphQL.Core;
@@ -14,90 +15,95 @@ namespace Octokit.GraphQL.Model
         {
         }
 
-        /// <summary>
-        /// Represents a Git commit.
-        /// </summary>
-        public Commit Commit => this.CreateProperty(x => x.Commit, Octokit.GraphQL.Model.Commit.Create);
+        public TResult Switch<TResult>(Expression<Func<Selector<TResult>, Selector<TResult>>> select) => default;
 
-        /// <summary>
-        /// Represents a comment on an Issue.
-        /// </summary>
-        public IssueComment IssueComment => this.CreateProperty(x => x.IssueComment, Octokit.GraphQL.Model.IssueComment.Create);
+        public class Selector<T>
+        {
+            /// <summary>
+            /// Represents a Git commit.
+            /// </summary>
+            public Selector<T> Commit(Func<Commit, T> selector) => default;
 
-        /// <summary>
-        /// Represents a mention made by one issue or pull request to another.
-        /// </summary>
-        public CrossReferencedEvent CrossReferencedEvent => this.CreateProperty(x => x.CrossReferencedEvent, Octokit.GraphQL.Model.CrossReferencedEvent.Create);
+            /// <summary>
+            /// Represents a comment on an Issue.
+            /// </summary>
+            public Selector<T> IssueComment(Func<IssueComment, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'closed' event on any `Closable`.
-        /// </summary>
-        public ClosedEvent ClosedEvent => this.CreateProperty(x => x.ClosedEvent, Octokit.GraphQL.Model.ClosedEvent.Create);
+            /// <summary>
+            /// Represents a mention made by one issue or pull request to another.
+            /// </summary>
+            public Selector<T> CrossReferencedEvent(Func<CrossReferencedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'reopened' event on any `Closable`.
-        /// </summary>
-        public ReopenedEvent ReopenedEvent => this.CreateProperty(x => x.ReopenedEvent, Octokit.GraphQL.Model.ReopenedEvent.Create);
+            /// <summary>
+            /// Represents a 'closed' event on any `Closable`.
+            /// </summary>
+            public Selector<T> ClosedEvent(Func<ClosedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'subscribed' event on a given `Subscribable`.
-        /// </summary>
-        public SubscribedEvent SubscribedEvent => this.CreateProperty(x => x.SubscribedEvent, Octokit.GraphQL.Model.SubscribedEvent.Create);
+            /// <summary>
+            /// Represents a 'reopened' event on any `Closable`.
+            /// </summary>
+            public Selector<T> ReopenedEvent(Func<ReopenedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'unsubscribed' event on a given `Subscribable`.
-        /// </summary>
-        public UnsubscribedEvent UnsubscribedEvent => this.CreateProperty(x => x.UnsubscribedEvent, Octokit.GraphQL.Model.UnsubscribedEvent.Create);
+            /// <summary>
+            /// Represents a 'subscribed' event on a given `Subscribable`.
+            /// </summary>
+            public Selector<T> SubscribedEvent(Func<SubscribedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'referenced' event on a given `ReferencedSubject`.
-        /// </summary>
-        public ReferencedEvent ReferencedEvent => this.CreateProperty(x => x.ReferencedEvent, Octokit.GraphQL.Model.ReferencedEvent.Create);
+            /// <summary>
+            /// Represents an 'unsubscribed' event on a given `Subscribable`.
+            /// </summary>
+            public Selector<T> UnsubscribedEvent(Func<UnsubscribedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'assigned' event on any assignable object.
-        /// </summary>
-        public AssignedEvent AssignedEvent => this.CreateProperty(x => x.AssignedEvent, Octokit.GraphQL.Model.AssignedEvent.Create);
+            /// <summary>
+            /// Represents a 'referenced' event on a given `ReferencedSubject`.
+            /// </summary>
+            public Selector<T> ReferencedEvent(Func<ReferencedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'unassigned' event on any assignable object.
-        /// </summary>
-        public UnassignedEvent UnassignedEvent => this.CreateProperty(x => x.UnassignedEvent, Octokit.GraphQL.Model.UnassignedEvent.Create);
+            /// <summary>
+            /// Represents an 'assigned' event on any assignable object.
+            /// </summary>
+            public Selector<T> AssignedEvent(Func<AssignedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'labeled' event on a given issue or pull request.
-        /// </summary>
-        public LabeledEvent LabeledEvent => this.CreateProperty(x => x.LabeledEvent, Octokit.GraphQL.Model.LabeledEvent.Create);
+            /// <summary>
+            /// Represents an 'unassigned' event on any assignable object.
+            /// </summary>
+            public Selector<T> UnassignedEvent(Func<UnassignedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'unlabeled' event on a given issue or pull request.
-        /// </summary>
-        public UnlabeledEvent UnlabeledEvent => this.CreateProperty(x => x.UnlabeledEvent, Octokit.GraphQL.Model.UnlabeledEvent.Create);
+            /// <summary>
+            /// Represents a 'labeled' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> LabeledEvent(Func<LabeledEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'milestoned' event on a given issue or pull request.
-        /// </summary>
-        public MilestonedEvent MilestonedEvent => this.CreateProperty(x => x.MilestonedEvent, Octokit.GraphQL.Model.MilestonedEvent.Create);
+            /// <summary>
+            /// Represents an 'unlabeled' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> UnlabeledEvent(Func<UnlabeledEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'demilestoned' event on a given issue or pull request.
-        /// </summary>
-        public DemilestonedEvent DemilestonedEvent => this.CreateProperty(x => x.DemilestonedEvent, Octokit.GraphQL.Model.DemilestonedEvent.Create);
+            /// <summary>
+            /// Represents a 'milestoned' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> MilestonedEvent(Func<MilestonedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'renamed' event on a given issue or pull request
-        /// </summary>
-        public RenamedTitleEvent RenamedTitleEvent => this.CreateProperty(x => x.RenamedTitleEvent, Octokit.GraphQL.Model.RenamedTitleEvent.Create);
+            /// <summary>
+            /// Represents a 'demilestoned' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> DemilestonedEvent(Func<DemilestonedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'locked' event on a given issue or pull request.
-        /// </summary>
-        public LockedEvent LockedEvent => this.CreateProperty(x => x.LockedEvent, Octokit.GraphQL.Model.LockedEvent.Create);
+            /// <summary>
+            /// Represents a 'renamed' event on a given issue or pull request
+            /// </summary>
+            public Selector<T> RenamedTitleEvent(Func<RenamedTitleEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'unlocked' event on a given issue or pull request.
-        /// </summary>
-        public UnlockedEvent UnlockedEvent => this.CreateProperty(x => x.UnlockedEvent, Octokit.GraphQL.Model.UnlockedEvent.Create);
+            /// <summary>
+            /// Represents a 'locked' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> LockedEvent(Func<LockedEvent, T> selector) => default;
+
+            /// <summary>
+            /// Represents an 'unlocked' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> UnlockedEvent(Func<UnlockedEvent, T> selector) => default;
+        }
 
         internal static IssueTimelineItem Create(Expression expression)
         {

--- a/Octokit.GraphQL/Model/IssueTimelineItems.cs
+++ b/Octokit.GraphQL/Model/IssueTimelineItems.cs
@@ -1,5 +1,6 @@
 namespace Octokit.GraphQL.Model
 {
+    using System;
     using System.Linq;
     using System.Linq.Expressions;
     using Octokit.GraphQL.Core;
@@ -14,115 +15,120 @@ namespace Octokit.GraphQL.Model
         {
         }
 
-        /// <summary>
-        /// Represents a comment on an Issue.
-        /// </summary>
-        public IssueComment IssueComment => this.CreateProperty(x => x.IssueComment, Octokit.GraphQL.Model.IssueComment.Create);
+        public TResult Switch<TResult>(Expression<Func<Selector<TResult>, Selector<TResult>>> select) => default;
 
-        /// <summary>
-        /// Represents a mention made by one issue or pull request to another.
-        /// </summary>
-        public CrossReferencedEvent CrossReferencedEvent => this.CreateProperty(x => x.CrossReferencedEvent, Octokit.GraphQL.Model.CrossReferencedEvent.Create);
+        public class Selector<T>
+        {
+            /// <summary>
+            /// Represents a comment on an Issue.
+            /// </summary>
+            public Selector<T> IssueComment(Func<IssueComment, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'added_to_project' event on a given issue or pull request.
-        /// </summary>
-        public AddedToProjectEvent AddedToProjectEvent => this.CreateProperty(x => x.AddedToProjectEvent, Octokit.GraphQL.Model.AddedToProjectEvent.Create);
+            /// <summary>
+            /// Represents a mention made by one issue or pull request to another.
+            /// </summary>
+            public Selector<T> CrossReferencedEvent(Func<CrossReferencedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'assigned' event on any assignable object.
-        /// </summary>
-        public AssignedEvent AssignedEvent => this.CreateProperty(x => x.AssignedEvent, Octokit.GraphQL.Model.AssignedEvent.Create);
+            /// <summary>
+            /// Represents a 'added_to_project' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> AddedToProjectEvent(Func<AddedToProjectEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'closed' event on any `Closable`.
-        /// </summary>
-        public ClosedEvent ClosedEvent => this.CreateProperty(x => x.ClosedEvent, Octokit.GraphQL.Model.ClosedEvent.Create);
+            /// <summary>
+            /// Represents an 'assigned' event on any assignable object.
+            /// </summary>
+            public Selector<T> AssignedEvent(Func<AssignedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'comment_deleted' event on a given issue or pull request.
-        /// </summary>
-        public CommentDeletedEvent CommentDeletedEvent => this.CreateProperty(x => x.CommentDeletedEvent, Octokit.GraphQL.Model.CommentDeletedEvent.Create);
+            /// <summary>
+            /// Represents a 'closed' event on any `Closable`.
+            /// </summary>
+            public Selector<T> ClosedEvent(Func<ClosedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'converted_note_to_issue' event on a given issue or pull request.
-        /// </summary>
-        public ConvertedNoteToIssueEvent ConvertedNoteToIssueEvent => this.CreateProperty(x => x.ConvertedNoteToIssueEvent, Octokit.GraphQL.Model.ConvertedNoteToIssueEvent.Create);
+            /// <summary>
+            /// Represents a 'comment_deleted' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> CommentDeletedEvent(Func<CommentDeletedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'demilestoned' event on a given issue or pull request.
-        /// </summary>
-        public DemilestonedEvent DemilestonedEvent => this.CreateProperty(x => x.DemilestonedEvent, Octokit.GraphQL.Model.DemilestonedEvent.Create);
+            /// <summary>
+            /// Represents a 'converted_note_to_issue' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> ConvertedNoteToIssueEvent(Func<ConvertedNoteToIssueEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'labeled' event on a given issue or pull request.
-        /// </summary>
-        public LabeledEvent LabeledEvent => this.CreateProperty(x => x.LabeledEvent, Octokit.GraphQL.Model.LabeledEvent.Create);
+            /// <summary>
+            /// Represents a 'demilestoned' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> DemilestonedEvent(Func<DemilestonedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'locked' event on a given issue or pull request.
-        /// </summary>
-        public LockedEvent LockedEvent => this.CreateProperty(x => x.LockedEvent, Octokit.GraphQL.Model.LockedEvent.Create);
+            /// <summary>
+            /// Represents a 'labeled' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> LabeledEvent(Func<LabeledEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'mentioned' event on a given issue or pull request.
-        /// </summary>
-        public MentionedEvent MentionedEvent => this.CreateProperty(x => x.MentionedEvent, Octokit.GraphQL.Model.MentionedEvent.Create);
+            /// <summary>
+            /// Represents a 'locked' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> LockedEvent(Func<LockedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'milestoned' event on a given issue or pull request.
-        /// </summary>
-        public MilestonedEvent MilestonedEvent => this.CreateProperty(x => x.MilestonedEvent, Octokit.GraphQL.Model.MilestonedEvent.Create);
+            /// <summary>
+            /// Represents a 'mentioned' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> MentionedEvent(Func<MentionedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'moved_columns_in_project' event on a given issue or pull request.
-        /// </summary>
-        public MovedColumnsInProjectEvent MovedColumnsInProjectEvent => this.CreateProperty(x => x.MovedColumnsInProjectEvent, Octokit.GraphQL.Model.MovedColumnsInProjectEvent.Create);
+            /// <summary>
+            /// Represents a 'milestoned' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> MilestonedEvent(Func<MilestonedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'referenced' event on a given `ReferencedSubject`.
-        /// </summary>
-        public ReferencedEvent ReferencedEvent => this.CreateProperty(x => x.ReferencedEvent, Octokit.GraphQL.Model.ReferencedEvent.Create);
+            /// <summary>
+            /// Represents a 'moved_columns_in_project' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> MovedColumnsInProjectEvent(Func<MovedColumnsInProjectEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'removed_from_project' event on a given issue or pull request.
-        /// </summary>
-        public RemovedFromProjectEvent RemovedFromProjectEvent => this.CreateProperty(x => x.RemovedFromProjectEvent, Octokit.GraphQL.Model.RemovedFromProjectEvent.Create);
+            /// <summary>
+            /// Represents a 'referenced' event on a given `ReferencedSubject`.
+            /// </summary>
+            public Selector<T> ReferencedEvent(Func<ReferencedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'renamed' event on a given issue or pull request
-        /// </summary>
-        public RenamedTitleEvent RenamedTitleEvent => this.CreateProperty(x => x.RenamedTitleEvent, Octokit.GraphQL.Model.RenamedTitleEvent.Create);
+            /// <summary>
+            /// Represents a 'removed_from_project' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> RemovedFromProjectEvent(Func<RemovedFromProjectEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'reopened' event on any `Closable`.
-        /// </summary>
-        public ReopenedEvent ReopenedEvent => this.CreateProperty(x => x.ReopenedEvent, Octokit.GraphQL.Model.ReopenedEvent.Create);
+            /// <summary>
+            /// Represents a 'renamed' event on a given issue or pull request
+            /// </summary>
+            public Selector<T> RenamedTitleEvent(Func<RenamedTitleEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'subscribed' event on a given `Subscribable`.
-        /// </summary>
-        public SubscribedEvent SubscribedEvent => this.CreateProperty(x => x.SubscribedEvent, Octokit.GraphQL.Model.SubscribedEvent.Create);
+            /// <summary>
+            /// Represents a 'reopened' event on any `Closable`.
+            /// </summary>
+            public Selector<T> ReopenedEvent(Func<ReopenedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'unassigned' event on any assignable object.
-        /// </summary>
-        public UnassignedEvent UnassignedEvent => this.CreateProperty(x => x.UnassignedEvent, Octokit.GraphQL.Model.UnassignedEvent.Create);
+            /// <summary>
+            /// Represents a 'subscribed' event on a given `Subscribable`.
+            /// </summary>
+            public Selector<T> SubscribedEvent(Func<SubscribedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'unlabeled' event on a given issue or pull request.
-        /// </summary>
-        public UnlabeledEvent UnlabeledEvent => this.CreateProperty(x => x.UnlabeledEvent, Octokit.GraphQL.Model.UnlabeledEvent.Create);
+            /// <summary>
+            /// Represents an 'unassigned' event on any assignable object.
+            /// </summary>
+            public Selector<T> UnassignedEvent(Func<UnassignedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'unlocked' event on a given issue or pull request.
-        /// </summary>
-        public UnlockedEvent UnlockedEvent => this.CreateProperty(x => x.UnlockedEvent, Octokit.GraphQL.Model.UnlockedEvent.Create);
+            /// <summary>
+            /// Represents an 'unlabeled' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> UnlabeledEvent(Func<UnlabeledEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'unsubscribed' event on a given `Subscribable`.
-        /// </summary>
-        public UnsubscribedEvent UnsubscribedEvent => this.CreateProperty(x => x.UnsubscribedEvent, Octokit.GraphQL.Model.UnsubscribedEvent.Create);
+            /// <summary>
+            /// Represents an 'unlocked' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> UnlockedEvent(Func<UnlockedEvent, T> selector) => default;
+
+            /// <summary>
+            /// Represents an 'unsubscribed' event on a given `Subscribable`.
+            /// </summary>
+            public Selector<T> UnsubscribedEvent(Func<UnsubscribedEvent, T> selector) => default;
+        }
 
         internal static IssueTimelineItems Create(Expression expression)
         {

--- a/Octokit.GraphQL/Model/MilestoneItem.cs
+++ b/Octokit.GraphQL/Model/MilestoneItem.cs
@@ -1,5 +1,6 @@
 namespace Octokit.GraphQL.Model
 {
+    using System;
     using System.Linq;
     using System.Linq.Expressions;
     using Octokit.GraphQL.Core;
@@ -14,15 +15,20 @@ namespace Octokit.GraphQL.Model
         {
         }
 
-        /// <summary>
-        /// An Issue is a place to discuss ideas, enhancements, tasks, and bugs for a project.
-        /// </summary>
-        public Issue Issue => this.CreateProperty(x => x.Issue, Octokit.GraphQL.Model.Issue.Create);
+        public TResult Switch<TResult>(Expression<Func<Selector<TResult>, Selector<TResult>>> select) => default;
 
-        /// <summary>
-        /// A repository pull request.
-        /// </summary>
-        public PullRequest PullRequest => this.CreateProperty(x => x.PullRequest, Octokit.GraphQL.Model.PullRequest.Create);
+        public class Selector<T>
+        {
+            /// <summary>
+            /// An Issue is a place to discuss ideas, enhancements, tasks, and bugs for a project.
+            /// </summary>
+            public Selector<T> Issue(Func<Issue, T> selector) => default;
+
+            /// <summary>
+            /// A repository pull request.
+            /// </summary>
+            public Selector<T> PullRequest(Func<PullRequest, T> selector) => default;
+        }
 
         internal static MilestoneItem Create(Expression expression)
         {

--- a/Octokit.GraphQL/Model/ProjectCardItem.cs
+++ b/Octokit.GraphQL/Model/ProjectCardItem.cs
@@ -1,5 +1,6 @@
 namespace Octokit.GraphQL.Model
 {
+    using System;
     using System.Linq;
     using System.Linq.Expressions;
     using Octokit.GraphQL.Core;
@@ -14,15 +15,20 @@ namespace Octokit.GraphQL.Model
         {
         }
 
-        /// <summary>
-        /// An Issue is a place to discuss ideas, enhancements, tasks, and bugs for a project.
-        /// </summary>
-        public Issue Issue => this.CreateProperty(x => x.Issue, Octokit.GraphQL.Model.Issue.Create);
+        public TResult Switch<TResult>(Expression<Func<Selector<TResult>, Selector<TResult>>> select) => default;
 
-        /// <summary>
-        /// A repository pull request.
-        /// </summary>
-        public PullRequest PullRequest => this.CreateProperty(x => x.PullRequest, Octokit.GraphQL.Model.PullRequest.Create);
+        public class Selector<T>
+        {
+            /// <summary>
+            /// An Issue is a place to discuss ideas, enhancements, tasks, and bugs for a project.
+            /// </summary>
+            public Selector<T> Issue(Func<Issue, T> selector) => default;
+
+            /// <summary>
+            /// A repository pull request.
+            /// </summary>
+            public Selector<T> PullRequest(Func<PullRequest, T> selector) => default;
+        }
 
         internal static ProjectCardItem Create(Expression expression)
         {

--- a/Octokit.GraphQL/Model/PullRequestTimelineItem.cs
+++ b/Octokit.GraphQL/Model/PullRequestTimelineItem.cs
@@ -1,5 +1,6 @@
 namespace Octokit.GraphQL.Model
 {
+    using System;
     using System.Linq;
     using System.Linq.Expressions;
     using Octokit.GraphQL.Core;
@@ -14,160 +15,165 @@ namespace Octokit.GraphQL.Model
         {
         }
 
-        /// <summary>
-        /// Represents a Git commit.
-        /// </summary>
-        public Commit Commit => this.CreateProperty(x => x.Commit, Octokit.GraphQL.Model.Commit.Create);
+        public TResult Switch<TResult>(Expression<Func<Selector<TResult>, Selector<TResult>>> select) => default;
 
-        /// <summary>
-        /// A thread of comments on a commit.
-        /// </summary>
-        public CommitCommentThread CommitCommentThread => this.CreateProperty(x => x.CommitCommentThread, Octokit.GraphQL.Model.CommitCommentThread.Create);
+        public class Selector<T>
+        {
+            /// <summary>
+            /// Represents a Git commit.
+            /// </summary>
+            public Selector<T> Commit(Func<Commit, T> selector) => default;
 
-        /// <summary>
-        /// A review object for a given pull request.
-        /// </summary>
-        public PullRequestReview PullRequestReview => this.CreateProperty(x => x.PullRequestReview, Octokit.GraphQL.Model.PullRequestReview.Create);
+            /// <summary>
+            /// A thread of comments on a commit.
+            /// </summary>
+            public Selector<T> CommitCommentThread(Func<CommitCommentThread, T> selector) => default;
 
-        /// <summary>
-        /// A threaded list of comments for a given pull request.
-        /// </summary>
-        public PullRequestReviewThread PullRequestReviewThread => this.CreateProperty(x => x.PullRequestReviewThread, Octokit.GraphQL.Model.PullRequestReviewThread.Create);
+            /// <summary>
+            /// A review object for a given pull request.
+            /// </summary>
+            public Selector<T> PullRequestReview(Func<PullRequestReview, T> selector) => default;
 
-        /// <summary>
-        /// A review comment associated with a given repository pull request.
-        /// </summary>
-        public PullRequestReviewComment PullRequestReviewComment => this.CreateProperty(x => x.PullRequestReviewComment, Octokit.GraphQL.Model.PullRequestReviewComment.Create);
+            /// <summary>
+            /// A threaded list of comments for a given pull request.
+            /// </summary>
+            public Selector<T> PullRequestReviewThread(Func<PullRequestReviewThread, T> selector) => default;
 
-        /// <summary>
-        /// Represents a comment on an Issue.
-        /// </summary>
-        public IssueComment IssueComment => this.CreateProperty(x => x.IssueComment, Octokit.GraphQL.Model.IssueComment.Create);
+            /// <summary>
+            /// A review comment associated with a given repository pull request.
+            /// </summary>
+            public Selector<T> PullRequestReviewComment(Func<PullRequestReviewComment, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'closed' event on any `Closable`.
-        /// </summary>
-        public ClosedEvent ClosedEvent => this.CreateProperty(x => x.ClosedEvent, Octokit.GraphQL.Model.ClosedEvent.Create);
+            /// <summary>
+            /// Represents a comment on an Issue.
+            /// </summary>
+            public Selector<T> IssueComment(Func<IssueComment, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'reopened' event on any `Closable`.
-        /// </summary>
-        public ReopenedEvent ReopenedEvent => this.CreateProperty(x => x.ReopenedEvent, Octokit.GraphQL.Model.ReopenedEvent.Create);
+            /// <summary>
+            /// Represents a 'closed' event on any `Closable`.
+            /// </summary>
+            public Selector<T> ClosedEvent(Func<ClosedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'subscribed' event on a given `Subscribable`.
-        /// </summary>
-        public SubscribedEvent SubscribedEvent => this.CreateProperty(x => x.SubscribedEvent, Octokit.GraphQL.Model.SubscribedEvent.Create);
+            /// <summary>
+            /// Represents a 'reopened' event on any `Closable`.
+            /// </summary>
+            public Selector<T> ReopenedEvent(Func<ReopenedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'unsubscribed' event on a given `Subscribable`.
-        /// </summary>
-        public UnsubscribedEvent UnsubscribedEvent => this.CreateProperty(x => x.UnsubscribedEvent, Octokit.GraphQL.Model.UnsubscribedEvent.Create);
+            /// <summary>
+            /// Represents a 'subscribed' event on a given `Subscribable`.
+            /// </summary>
+            public Selector<T> SubscribedEvent(Func<SubscribedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'merged' event on a given pull request.
-        /// </summary>
-        public MergedEvent MergedEvent => this.CreateProperty(x => x.MergedEvent, Octokit.GraphQL.Model.MergedEvent.Create);
+            /// <summary>
+            /// Represents an 'unsubscribed' event on a given `Subscribable`.
+            /// </summary>
+            public Selector<T> UnsubscribedEvent(Func<UnsubscribedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'referenced' event on a given `ReferencedSubject`.
-        /// </summary>
-        public ReferencedEvent ReferencedEvent => this.CreateProperty(x => x.ReferencedEvent, Octokit.GraphQL.Model.ReferencedEvent.Create);
+            /// <summary>
+            /// Represents a 'merged' event on a given pull request.
+            /// </summary>
+            public Selector<T> MergedEvent(Func<MergedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a mention made by one issue or pull request to another.
-        /// </summary>
-        public CrossReferencedEvent CrossReferencedEvent => this.CreateProperty(x => x.CrossReferencedEvent, Octokit.GraphQL.Model.CrossReferencedEvent.Create);
+            /// <summary>
+            /// Represents a 'referenced' event on a given `ReferencedSubject`.
+            /// </summary>
+            public Selector<T> ReferencedEvent(Func<ReferencedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'assigned' event on any assignable object.
-        /// </summary>
-        public AssignedEvent AssignedEvent => this.CreateProperty(x => x.AssignedEvent, Octokit.GraphQL.Model.AssignedEvent.Create);
+            /// <summary>
+            /// Represents a mention made by one issue or pull request to another.
+            /// </summary>
+            public Selector<T> CrossReferencedEvent(Func<CrossReferencedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'unassigned' event on any assignable object.
-        /// </summary>
-        public UnassignedEvent UnassignedEvent => this.CreateProperty(x => x.UnassignedEvent, Octokit.GraphQL.Model.UnassignedEvent.Create);
+            /// <summary>
+            /// Represents an 'assigned' event on any assignable object.
+            /// </summary>
+            public Selector<T> AssignedEvent(Func<AssignedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'labeled' event on a given issue or pull request.
-        /// </summary>
-        public LabeledEvent LabeledEvent => this.CreateProperty(x => x.LabeledEvent, Octokit.GraphQL.Model.LabeledEvent.Create);
+            /// <summary>
+            /// Represents an 'unassigned' event on any assignable object.
+            /// </summary>
+            public Selector<T> UnassignedEvent(Func<UnassignedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'unlabeled' event on a given issue or pull request.
-        /// </summary>
-        public UnlabeledEvent UnlabeledEvent => this.CreateProperty(x => x.UnlabeledEvent, Octokit.GraphQL.Model.UnlabeledEvent.Create);
+            /// <summary>
+            /// Represents a 'labeled' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> LabeledEvent(Func<LabeledEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'milestoned' event on a given issue or pull request.
-        /// </summary>
-        public MilestonedEvent MilestonedEvent => this.CreateProperty(x => x.MilestonedEvent, Octokit.GraphQL.Model.MilestonedEvent.Create);
+            /// <summary>
+            /// Represents an 'unlabeled' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> UnlabeledEvent(Func<UnlabeledEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'demilestoned' event on a given issue or pull request.
-        /// </summary>
-        public DemilestonedEvent DemilestonedEvent => this.CreateProperty(x => x.DemilestonedEvent, Octokit.GraphQL.Model.DemilestonedEvent.Create);
+            /// <summary>
+            /// Represents a 'milestoned' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> MilestonedEvent(Func<MilestonedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'renamed' event on a given issue or pull request
-        /// </summary>
-        public RenamedTitleEvent RenamedTitleEvent => this.CreateProperty(x => x.RenamedTitleEvent, Octokit.GraphQL.Model.RenamedTitleEvent.Create);
+            /// <summary>
+            /// Represents a 'demilestoned' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> DemilestonedEvent(Func<DemilestonedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'locked' event on a given issue or pull request.
-        /// </summary>
-        public LockedEvent LockedEvent => this.CreateProperty(x => x.LockedEvent, Octokit.GraphQL.Model.LockedEvent.Create);
+            /// <summary>
+            /// Represents a 'renamed' event on a given issue or pull request
+            /// </summary>
+            public Selector<T> RenamedTitleEvent(Func<RenamedTitleEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'unlocked' event on a given issue or pull request.
-        /// </summary>
-        public UnlockedEvent UnlockedEvent => this.CreateProperty(x => x.UnlockedEvent, Octokit.GraphQL.Model.UnlockedEvent.Create);
+            /// <summary>
+            /// Represents a 'locked' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> LockedEvent(Func<LockedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'deployed' event on a given pull request.
-        /// </summary>
-        public DeployedEvent DeployedEvent => this.CreateProperty(x => x.DeployedEvent, Octokit.GraphQL.Model.DeployedEvent.Create);
+            /// <summary>
+            /// Represents an 'unlocked' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> UnlockedEvent(Func<UnlockedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'deployment_environment_changed' event on a given pull request.
-        /// </summary>
-        public DeploymentEnvironmentChangedEvent DeploymentEnvironmentChangedEvent => this.CreateProperty(x => x.DeploymentEnvironmentChangedEvent, Octokit.GraphQL.Model.DeploymentEnvironmentChangedEvent.Create);
+            /// <summary>
+            /// Represents a 'deployed' event on a given pull request.
+            /// </summary>
+            public Selector<T> DeployedEvent(Func<DeployedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'head_ref_deleted' event on a given pull request.
-        /// </summary>
-        public HeadRefDeletedEvent HeadRefDeletedEvent => this.CreateProperty(x => x.HeadRefDeletedEvent, Octokit.GraphQL.Model.HeadRefDeletedEvent.Create);
+            /// <summary>
+            /// Represents a 'deployment_environment_changed' event on a given pull request.
+            /// </summary>
+            public Selector<T> DeploymentEnvironmentChangedEvent(Func<DeploymentEnvironmentChangedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'head_ref_restored' event on a given pull request.
-        /// </summary>
-        public HeadRefRestoredEvent HeadRefRestoredEvent => this.CreateProperty(x => x.HeadRefRestoredEvent, Octokit.GraphQL.Model.HeadRefRestoredEvent.Create);
+            /// <summary>
+            /// Represents a 'head_ref_deleted' event on a given pull request.
+            /// </summary>
+            public Selector<T> HeadRefDeletedEvent(Func<HeadRefDeletedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'head_ref_force_pushed' event on a given pull request.
-        /// </summary>
-        public HeadRefForcePushedEvent HeadRefForcePushedEvent => this.CreateProperty(x => x.HeadRefForcePushedEvent, Octokit.GraphQL.Model.HeadRefForcePushedEvent.Create);
+            /// <summary>
+            /// Represents a 'head_ref_restored' event on a given pull request.
+            /// </summary>
+            public Selector<T> HeadRefRestoredEvent(Func<HeadRefRestoredEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'base_ref_force_pushed' event on a given pull request.
-        /// </summary>
-        public BaseRefForcePushedEvent BaseRefForcePushedEvent => this.CreateProperty(x => x.BaseRefForcePushedEvent, Octokit.GraphQL.Model.BaseRefForcePushedEvent.Create);
+            /// <summary>
+            /// Represents a 'head_ref_force_pushed' event on a given pull request.
+            /// </summary>
+            public Selector<T> HeadRefForcePushedEvent(Func<HeadRefForcePushedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'review_requested' event on a given pull request.
-        /// </summary>
-        public ReviewRequestedEvent ReviewRequestedEvent => this.CreateProperty(x => x.ReviewRequestedEvent, Octokit.GraphQL.Model.ReviewRequestedEvent.Create);
+            /// <summary>
+            /// Represents a 'base_ref_force_pushed' event on a given pull request.
+            /// </summary>
+            public Selector<T> BaseRefForcePushedEvent(Func<BaseRefForcePushedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'review_request_removed' event on a given pull request.
-        /// </summary>
-        public ReviewRequestRemovedEvent ReviewRequestRemovedEvent => this.CreateProperty(x => x.ReviewRequestRemovedEvent, Octokit.GraphQL.Model.ReviewRequestRemovedEvent.Create);
+            /// <summary>
+            /// Represents an 'review_requested' event on a given pull request.
+            /// </summary>
+            public Selector<T> ReviewRequestedEvent(Func<ReviewRequestedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'review_dismissed' event on a given issue or pull request.
-        /// </summary>
-        public ReviewDismissedEvent ReviewDismissedEvent => this.CreateProperty(x => x.ReviewDismissedEvent, Octokit.GraphQL.Model.ReviewDismissedEvent.Create);
+            /// <summary>
+            /// Represents an 'review_request_removed' event on a given pull request.
+            /// </summary>
+            public Selector<T> ReviewRequestRemovedEvent(Func<ReviewRequestRemovedEvent, T> selector) => default;
+
+            /// <summary>
+            /// Represents a 'review_dismissed' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> ReviewDismissedEvent(Func<ReviewDismissedEvent, T> selector) => default;
+        }
 
         internal static PullRequestTimelineItem Create(Expression expression)
         {

--- a/Octokit.GraphQL/Model/PullRequestTimelineItems.cs
+++ b/Octokit.GraphQL/Model/PullRequestTimelineItems.cs
@@ -1,5 +1,6 @@
 namespace Octokit.GraphQL.Model
 {
+    using System;
     using System.Linq;
     using System.Linq.Expressions;
     using Octokit.GraphQL.Core;
@@ -14,185 +15,190 @@ namespace Octokit.GraphQL.Model
         {
         }
 
-        /// <summary>
-        /// Represents a Git commit part of a pull request.
-        /// </summary>
-        public PullRequestCommit PullRequestCommit => this.CreateProperty(x => x.PullRequestCommit, Octokit.GraphQL.Model.PullRequestCommit.Create);
+        public TResult Switch<TResult>(Expression<Func<Selector<TResult>, Selector<TResult>>> select) => default;
 
-        /// <summary>
-        /// A review object for a given pull request.
-        /// </summary>
-        public PullRequestReview PullRequestReview => this.CreateProperty(x => x.PullRequestReview, Octokit.GraphQL.Model.PullRequestReview.Create);
+        public class Selector<T>
+        {
+            /// <summary>
+            /// Represents a Git commit part of a pull request.
+            /// </summary>
+            public Selector<T> PullRequestCommit(Func<PullRequestCommit, T> selector) => default;
 
-        /// <summary>
-        /// A threaded list of comments for a given pull request.
-        /// </summary>
-        public PullRequestReviewThread PullRequestReviewThread => this.CreateProperty(x => x.PullRequestReviewThread, Octokit.GraphQL.Model.PullRequestReviewThread.Create);
+            /// <summary>
+            /// A review object for a given pull request.
+            /// </summary>
+            public Selector<T> PullRequestReview(Func<PullRequestReview, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'base_ref_changed' event on a given issue or pull request.
-        /// </summary>
-        public BaseRefChangedEvent BaseRefChangedEvent => this.CreateProperty(x => x.BaseRefChangedEvent, Octokit.GraphQL.Model.BaseRefChangedEvent.Create);
+            /// <summary>
+            /// A threaded list of comments for a given pull request.
+            /// </summary>
+            public Selector<T> PullRequestReviewThread(Func<PullRequestReviewThread, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'base_ref_force_pushed' event on a given pull request.
-        /// </summary>
-        public BaseRefForcePushedEvent BaseRefForcePushedEvent => this.CreateProperty(x => x.BaseRefForcePushedEvent, Octokit.GraphQL.Model.BaseRefForcePushedEvent.Create);
+            /// <summary>
+            /// Represents a 'base_ref_changed' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> BaseRefChangedEvent(Func<BaseRefChangedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'deployed' event on a given pull request.
-        /// </summary>
-        public DeployedEvent DeployedEvent => this.CreateProperty(x => x.DeployedEvent, Octokit.GraphQL.Model.DeployedEvent.Create);
+            /// <summary>
+            /// Represents a 'base_ref_force_pushed' event on a given pull request.
+            /// </summary>
+            public Selector<T> BaseRefForcePushedEvent(Func<BaseRefForcePushedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'deployment_environment_changed' event on a given pull request.
-        /// </summary>
-        public DeploymentEnvironmentChangedEvent DeploymentEnvironmentChangedEvent => this.CreateProperty(x => x.DeploymentEnvironmentChangedEvent, Octokit.GraphQL.Model.DeploymentEnvironmentChangedEvent.Create);
+            /// <summary>
+            /// Represents a 'deployed' event on a given pull request.
+            /// </summary>
+            public Selector<T> DeployedEvent(Func<DeployedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'head_ref_deleted' event on a given pull request.
-        /// </summary>
-        public HeadRefDeletedEvent HeadRefDeletedEvent => this.CreateProperty(x => x.HeadRefDeletedEvent, Octokit.GraphQL.Model.HeadRefDeletedEvent.Create);
+            /// <summary>
+            /// Represents a 'deployment_environment_changed' event on a given pull request.
+            /// </summary>
+            public Selector<T> DeploymentEnvironmentChangedEvent(Func<DeploymentEnvironmentChangedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'head_ref_force_pushed' event on a given pull request.
-        /// </summary>
-        public HeadRefForcePushedEvent HeadRefForcePushedEvent => this.CreateProperty(x => x.HeadRefForcePushedEvent, Octokit.GraphQL.Model.HeadRefForcePushedEvent.Create);
+            /// <summary>
+            /// Represents a 'head_ref_deleted' event on a given pull request.
+            /// </summary>
+            public Selector<T> HeadRefDeletedEvent(Func<HeadRefDeletedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'head_ref_restored' event on a given pull request.
-        /// </summary>
-        public HeadRefRestoredEvent HeadRefRestoredEvent => this.CreateProperty(x => x.HeadRefRestoredEvent, Octokit.GraphQL.Model.HeadRefRestoredEvent.Create);
+            /// <summary>
+            /// Represents a 'head_ref_force_pushed' event on a given pull request.
+            /// </summary>
+            public Selector<T> HeadRefForcePushedEvent(Func<HeadRefForcePushedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'merged' event on a given pull request.
-        /// </summary>
-        public MergedEvent MergedEvent => this.CreateProperty(x => x.MergedEvent, Octokit.GraphQL.Model.MergedEvent.Create);
+            /// <summary>
+            /// Represents a 'head_ref_restored' event on a given pull request.
+            /// </summary>
+            public Selector<T> HeadRefRestoredEvent(Func<HeadRefRestoredEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'review_dismissed' event on a given issue or pull request.
-        /// </summary>
-        public ReviewDismissedEvent ReviewDismissedEvent => this.CreateProperty(x => x.ReviewDismissedEvent, Octokit.GraphQL.Model.ReviewDismissedEvent.Create);
+            /// <summary>
+            /// Represents a 'merged' event on a given pull request.
+            /// </summary>
+            public Selector<T> MergedEvent(Func<MergedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'review_requested' event on a given pull request.
-        /// </summary>
-        public ReviewRequestedEvent ReviewRequestedEvent => this.CreateProperty(x => x.ReviewRequestedEvent, Octokit.GraphQL.Model.ReviewRequestedEvent.Create);
+            /// <summary>
+            /// Represents a 'review_dismissed' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> ReviewDismissedEvent(Func<ReviewDismissedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'review_request_removed' event on a given pull request.
-        /// </summary>
-        public ReviewRequestRemovedEvent ReviewRequestRemovedEvent => this.CreateProperty(x => x.ReviewRequestRemovedEvent, Octokit.GraphQL.Model.ReviewRequestRemovedEvent.Create);
+            /// <summary>
+            /// Represents an 'review_requested' event on a given pull request.
+            /// </summary>
+            public Selector<T> ReviewRequestedEvent(Func<ReviewRequestedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a comment on an Issue.
-        /// </summary>
-        public IssueComment IssueComment => this.CreateProperty(x => x.IssueComment, Octokit.GraphQL.Model.IssueComment.Create);
+            /// <summary>
+            /// Represents an 'review_request_removed' event on a given pull request.
+            /// </summary>
+            public Selector<T> ReviewRequestRemovedEvent(Func<ReviewRequestRemovedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a mention made by one issue or pull request to another.
-        /// </summary>
-        public CrossReferencedEvent CrossReferencedEvent => this.CreateProperty(x => x.CrossReferencedEvent, Octokit.GraphQL.Model.CrossReferencedEvent.Create);
+            /// <summary>
+            /// Represents a comment on an Issue.
+            /// </summary>
+            public Selector<T> IssueComment(Func<IssueComment, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'added_to_project' event on a given issue or pull request.
-        /// </summary>
-        public AddedToProjectEvent AddedToProjectEvent => this.CreateProperty(x => x.AddedToProjectEvent, Octokit.GraphQL.Model.AddedToProjectEvent.Create);
+            /// <summary>
+            /// Represents a mention made by one issue or pull request to another.
+            /// </summary>
+            public Selector<T> CrossReferencedEvent(Func<CrossReferencedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'assigned' event on any assignable object.
-        /// </summary>
-        public AssignedEvent AssignedEvent => this.CreateProperty(x => x.AssignedEvent, Octokit.GraphQL.Model.AssignedEvent.Create);
+            /// <summary>
+            /// Represents a 'added_to_project' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> AddedToProjectEvent(Func<AddedToProjectEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'closed' event on any `Closable`.
-        /// </summary>
-        public ClosedEvent ClosedEvent => this.CreateProperty(x => x.ClosedEvent, Octokit.GraphQL.Model.ClosedEvent.Create);
+            /// <summary>
+            /// Represents an 'assigned' event on any assignable object.
+            /// </summary>
+            public Selector<T> AssignedEvent(Func<AssignedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'comment_deleted' event on a given issue or pull request.
-        /// </summary>
-        public CommentDeletedEvent CommentDeletedEvent => this.CreateProperty(x => x.CommentDeletedEvent, Octokit.GraphQL.Model.CommentDeletedEvent.Create);
+            /// <summary>
+            /// Represents a 'closed' event on any `Closable`.
+            /// </summary>
+            public Selector<T> ClosedEvent(Func<ClosedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'converted_note_to_issue' event on a given issue or pull request.
-        /// </summary>
-        public ConvertedNoteToIssueEvent ConvertedNoteToIssueEvent => this.CreateProperty(x => x.ConvertedNoteToIssueEvent, Octokit.GraphQL.Model.ConvertedNoteToIssueEvent.Create);
+            /// <summary>
+            /// Represents a 'comment_deleted' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> CommentDeletedEvent(Func<CommentDeletedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'demilestoned' event on a given issue or pull request.
-        /// </summary>
-        public DemilestonedEvent DemilestonedEvent => this.CreateProperty(x => x.DemilestonedEvent, Octokit.GraphQL.Model.DemilestonedEvent.Create);
+            /// <summary>
+            /// Represents a 'converted_note_to_issue' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> ConvertedNoteToIssueEvent(Func<ConvertedNoteToIssueEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'labeled' event on a given issue or pull request.
-        /// </summary>
-        public LabeledEvent LabeledEvent => this.CreateProperty(x => x.LabeledEvent, Octokit.GraphQL.Model.LabeledEvent.Create);
+            /// <summary>
+            /// Represents a 'demilestoned' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> DemilestonedEvent(Func<DemilestonedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'locked' event on a given issue or pull request.
-        /// </summary>
-        public LockedEvent LockedEvent => this.CreateProperty(x => x.LockedEvent, Octokit.GraphQL.Model.LockedEvent.Create);
+            /// <summary>
+            /// Represents a 'labeled' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> LabeledEvent(Func<LabeledEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'mentioned' event on a given issue or pull request.
-        /// </summary>
-        public MentionedEvent MentionedEvent => this.CreateProperty(x => x.MentionedEvent, Octokit.GraphQL.Model.MentionedEvent.Create);
+            /// <summary>
+            /// Represents a 'locked' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> LockedEvent(Func<LockedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'milestoned' event on a given issue or pull request.
-        /// </summary>
-        public MilestonedEvent MilestonedEvent => this.CreateProperty(x => x.MilestonedEvent, Octokit.GraphQL.Model.MilestonedEvent.Create);
+            /// <summary>
+            /// Represents a 'mentioned' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> MentionedEvent(Func<MentionedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'moved_columns_in_project' event on a given issue or pull request.
-        /// </summary>
-        public MovedColumnsInProjectEvent MovedColumnsInProjectEvent => this.CreateProperty(x => x.MovedColumnsInProjectEvent, Octokit.GraphQL.Model.MovedColumnsInProjectEvent.Create);
+            /// <summary>
+            /// Represents a 'milestoned' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> MilestonedEvent(Func<MilestonedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'referenced' event on a given `ReferencedSubject`.
-        /// </summary>
-        public ReferencedEvent ReferencedEvent => this.CreateProperty(x => x.ReferencedEvent, Octokit.GraphQL.Model.ReferencedEvent.Create);
+            /// <summary>
+            /// Represents a 'moved_columns_in_project' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> MovedColumnsInProjectEvent(Func<MovedColumnsInProjectEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'removed_from_project' event on a given issue or pull request.
-        /// </summary>
-        public RemovedFromProjectEvent RemovedFromProjectEvent => this.CreateProperty(x => x.RemovedFromProjectEvent, Octokit.GraphQL.Model.RemovedFromProjectEvent.Create);
+            /// <summary>
+            /// Represents a 'referenced' event on a given `ReferencedSubject`.
+            /// </summary>
+            public Selector<T> ReferencedEvent(Func<ReferencedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'renamed' event on a given issue or pull request
-        /// </summary>
-        public RenamedTitleEvent RenamedTitleEvent => this.CreateProperty(x => x.RenamedTitleEvent, Octokit.GraphQL.Model.RenamedTitleEvent.Create);
+            /// <summary>
+            /// Represents a 'removed_from_project' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> RemovedFromProjectEvent(Func<RemovedFromProjectEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'reopened' event on any `Closable`.
-        /// </summary>
-        public ReopenedEvent ReopenedEvent => this.CreateProperty(x => x.ReopenedEvent, Octokit.GraphQL.Model.ReopenedEvent.Create);
+            /// <summary>
+            /// Represents a 'renamed' event on a given issue or pull request
+            /// </summary>
+            public Selector<T> RenamedTitleEvent(Func<RenamedTitleEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents a 'subscribed' event on a given `Subscribable`.
-        /// </summary>
-        public SubscribedEvent SubscribedEvent => this.CreateProperty(x => x.SubscribedEvent, Octokit.GraphQL.Model.SubscribedEvent.Create);
+            /// <summary>
+            /// Represents a 'reopened' event on any `Closable`.
+            /// </summary>
+            public Selector<T> ReopenedEvent(Func<ReopenedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'unassigned' event on any assignable object.
-        /// </summary>
-        public UnassignedEvent UnassignedEvent => this.CreateProperty(x => x.UnassignedEvent, Octokit.GraphQL.Model.UnassignedEvent.Create);
+            /// <summary>
+            /// Represents a 'subscribed' event on a given `Subscribable`.
+            /// </summary>
+            public Selector<T> SubscribedEvent(Func<SubscribedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'unlabeled' event on a given issue or pull request.
-        /// </summary>
-        public UnlabeledEvent UnlabeledEvent => this.CreateProperty(x => x.UnlabeledEvent, Octokit.GraphQL.Model.UnlabeledEvent.Create);
+            /// <summary>
+            /// Represents an 'unassigned' event on any assignable object.
+            /// </summary>
+            public Selector<T> UnassignedEvent(Func<UnassignedEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'unlocked' event on a given issue or pull request.
-        /// </summary>
-        public UnlockedEvent UnlockedEvent => this.CreateProperty(x => x.UnlockedEvent, Octokit.GraphQL.Model.UnlockedEvent.Create);
+            /// <summary>
+            /// Represents an 'unlabeled' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> UnlabeledEvent(Func<UnlabeledEvent, T> selector) => default;
 
-        /// <summary>
-        /// Represents an 'unsubscribed' event on a given `Subscribable`.
-        /// </summary>
-        public UnsubscribedEvent UnsubscribedEvent => this.CreateProperty(x => x.UnsubscribedEvent, Octokit.GraphQL.Model.UnsubscribedEvent.Create);
+            /// <summary>
+            /// Represents an 'unlocked' event on a given issue or pull request.
+            /// </summary>
+            public Selector<T> UnlockedEvent(Func<UnlockedEvent, T> selector) => default;
+
+            /// <summary>
+            /// Represents an 'unsubscribed' event on a given `Subscribable`.
+            /// </summary>
+            public Selector<T> UnsubscribedEvent(Func<UnsubscribedEvent, T> selector) => default;
+        }
 
         internal static PullRequestTimelineItems Create(Expression expression)
         {

--- a/Octokit.GraphQL/Model/PushAllowanceActor.cs
+++ b/Octokit.GraphQL/Model/PushAllowanceActor.cs
@@ -1,5 +1,6 @@
 namespace Octokit.GraphQL.Model
 {
+    using System;
     using System.Linq;
     using System.Linq.Expressions;
     using Octokit.GraphQL.Core;
@@ -14,15 +15,20 @@ namespace Octokit.GraphQL.Model
         {
         }
 
-        /// <summary>
-        /// A user is an individual's account on GitHub that owns repositories and can make new content.
-        /// </summary>
-        public User User => this.CreateProperty(x => x.User, Octokit.GraphQL.Model.User.Create);
+        public TResult Switch<TResult>(Expression<Func<Selector<TResult>, Selector<TResult>>> select) => default;
 
-        /// <summary>
-        /// A team of users in an organization.
-        /// </summary>
-        public Team Team => this.CreateProperty(x => x.Team, Octokit.GraphQL.Model.Team.Create);
+        public class Selector<T>
+        {
+            /// <summary>
+            /// A user is an individual's account on GitHub that owns repositories and can make new content.
+            /// </summary>
+            public Selector<T> User(Func<User, T> selector) => default;
+
+            /// <summary>
+            /// A team of users in an organization.
+            /// </summary>
+            public Selector<T> Team(Func<Team, T> selector) => default;
+        }
 
         internal static PushAllowanceActor Create(Expression expression)
         {

--- a/Octokit.GraphQL/Model/ReferencedSubject.cs
+++ b/Octokit.GraphQL/Model/ReferencedSubject.cs
@@ -1,5 +1,6 @@
 namespace Octokit.GraphQL.Model
 {
+    using System;
     using System.Linq;
     using System.Linq.Expressions;
     using Octokit.GraphQL.Core;
@@ -14,15 +15,20 @@ namespace Octokit.GraphQL.Model
         {
         }
 
-        /// <summary>
-        /// An Issue is a place to discuss ideas, enhancements, tasks, and bugs for a project.
-        /// </summary>
-        public Issue Issue => this.CreateProperty(x => x.Issue, Octokit.GraphQL.Model.Issue.Create);
+        public TResult Switch<TResult>(Expression<Func<Selector<TResult>, Selector<TResult>>> select) => default;
 
-        /// <summary>
-        /// A repository pull request.
-        /// </summary>
-        public PullRequest PullRequest => this.CreateProperty(x => x.PullRequest, Octokit.GraphQL.Model.PullRequest.Create);
+        public class Selector<T>
+        {
+            /// <summary>
+            /// An Issue is a place to discuss ideas, enhancements, tasks, and bugs for a project.
+            /// </summary>
+            public Selector<T> Issue(Func<Issue, T> selector) => default;
+
+            /// <summary>
+            /// A repository pull request.
+            /// </summary>
+            public Selector<T> PullRequest(Func<PullRequest, T> selector) => default;
+        }
 
         internal static ReferencedSubject Create(Expression expression)
         {

--- a/Octokit.GraphQL/Model/RenamedTitleSubject.cs
+++ b/Octokit.GraphQL/Model/RenamedTitleSubject.cs
@@ -1,5 +1,6 @@
 namespace Octokit.GraphQL.Model
 {
+    using System;
     using System.Linq;
     using System.Linq.Expressions;
     using Octokit.GraphQL.Core;
@@ -14,15 +15,20 @@ namespace Octokit.GraphQL.Model
         {
         }
 
-        /// <summary>
-        /// An Issue is a place to discuss ideas, enhancements, tasks, and bugs for a project.
-        /// </summary>
-        public Issue Issue => this.CreateProperty(x => x.Issue, Octokit.GraphQL.Model.Issue.Create);
+        public TResult Switch<TResult>(Expression<Func<Selector<TResult>, Selector<TResult>>> select) => default;
 
-        /// <summary>
-        /// A repository pull request.
-        /// </summary>
-        public PullRequest PullRequest => this.CreateProperty(x => x.PullRequest, Octokit.GraphQL.Model.PullRequest.Create);
+        public class Selector<T>
+        {
+            /// <summary>
+            /// An Issue is a place to discuss ideas, enhancements, tasks, and bugs for a project.
+            /// </summary>
+            public Selector<T> Issue(Func<Issue, T> selector) => default;
+
+            /// <summary>
+            /// A repository pull request.
+            /// </summary>
+            public Selector<T> PullRequest(Func<PullRequest, T> selector) => default;
+        }
 
         internal static RenamedTitleSubject Create(Expression expression)
         {

--- a/Octokit.GraphQL/Model/RequestedReviewer.cs
+++ b/Octokit.GraphQL/Model/RequestedReviewer.cs
@@ -1,5 +1,6 @@
 namespace Octokit.GraphQL.Model
 {
+    using System;
     using System.Linq;
     using System.Linq.Expressions;
     using Octokit.GraphQL.Core;
@@ -14,15 +15,20 @@ namespace Octokit.GraphQL.Model
         {
         }
 
-        /// <summary>
-        /// A user is an individual's account on GitHub that owns repositories and can make new content.
-        /// </summary>
-        public User User => this.CreateProperty(x => x.User, Octokit.GraphQL.Model.User.Create);
+        public TResult Switch<TResult>(Expression<Func<Selector<TResult>, Selector<TResult>>> select) => default;
 
-        /// <summary>
-        /// A team of users in an organization.
-        /// </summary>
-        public Team Team => this.CreateProperty(x => x.Team, Octokit.GraphQL.Model.Team.Create);
+        public class Selector<T>
+        {
+            /// <summary>
+            /// A user is an individual's account on GitHub that owns repositories and can make new content.
+            /// </summary>
+            public Selector<T> User(Func<User, T> selector) => default;
+
+            /// <summary>
+            /// A team of users in an organization.
+            /// </summary>
+            public Selector<T> Team(Func<Team, T> selector) => default;
+        }
 
         internal static RequestedReviewer Create(Expression expression)
         {

--- a/Octokit.GraphQL/Model/ReviewDismissalAllowanceActor.cs
+++ b/Octokit.GraphQL/Model/ReviewDismissalAllowanceActor.cs
@@ -1,5 +1,6 @@
 namespace Octokit.GraphQL.Model
 {
+    using System;
     using System.Linq;
     using System.Linq.Expressions;
     using Octokit.GraphQL.Core;
@@ -14,15 +15,20 @@ namespace Octokit.GraphQL.Model
         {
         }
 
-        /// <summary>
-        /// A user is an individual's account on GitHub that owns repositories and can make new content.
-        /// </summary>
-        public User User => this.CreateProperty(x => x.User, Octokit.GraphQL.Model.User.Create);
+        public TResult Switch<TResult>(Expression<Func<Selector<TResult>, Selector<TResult>>> select) => default;
 
-        /// <summary>
-        /// A team of users in an organization.
-        /// </summary>
-        public Team Team => this.CreateProperty(x => x.Team, Octokit.GraphQL.Model.Team.Create);
+        public class Selector<T>
+        {
+            /// <summary>
+            /// A user is an individual's account on GitHub that owns repositories and can make new content.
+            /// </summary>
+            public Selector<T> User(Func<User, T> selector) => default;
+
+            /// <summary>
+            /// A team of users in an organization.
+            /// </summary>
+            public Selector<T> Team(Func<Team, T> selector) => default;
+        }
 
         internal static ReviewDismissalAllowanceActor Create(Expression expression)
         {

--- a/Octokit.GraphQL/Model/SearchResultItem.cs
+++ b/Octokit.GraphQL/Model/SearchResultItem.cs
@@ -1,5 +1,6 @@
 namespace Octokit.GraphQL.Model
 {
+    using System;
     using System.Linq;
     using System.Linq.Expressions;
     using Octokit.GraphQL.Core;
@@ -14,35 +15,40 @@ namespace Octokit.GraphQL.Model
         {
         }
 
-        /// <summary>
-        /// An Issue is a place to discuss ideas, enhancements, tasks, and bugs for a project.
-        /// </summary>
-        public Issue Issue => this.CreateProperty(x => x.Issue, Octokit.GraphQL.Model.Issue.Create);
+        public TResult Switch<TResult>(Expression<Func<Selector<TResult>, Selector<TResult>>> select) => default;
 
-        /// <summary>
-        /// A repository pull request.
-        /// </summary>
-        public PullRequest PullRequest => this.CreateProperty(x => x.PullRequest, Octokit.GraphQL.Model.PullRequest.Create);
+        public class Selector<T>
+        {
+            /// <summary>
+            /// An Issue is a place to discuss ideas, enhancements, tasks, and bugs for a project.
+            /// </summary>
+            public Selector<T> Issue(Func<Issue, T> selector) => default;
 
-        /// <summary>
-        /// A repository contains the content for a project.
-        /// </summary>
-        public Repository Repository => this.CreateProperty(x => x.Repository, Octokit.GraphQL.Model.Repository.Create);
+            /// <summary>
+            /// A repository pull request.
+            /// </summary>
+            public Selector<T> PullRequest(Func<PullRequest, T> selector) => default;
 
-        /// <summary>
-        /// A user is an individual's account on GitHub that owns repositories and can make new content.
-        /// </summary>
-        public User User => this.CreateProperty(x => x.User, Octokit.GraphQL.Model.User.Create);
+            /// <summary>
+            /// A repository contains the content for a project.
+            /// </summary>
+            public Selector<T> Repository(Func<Repository, T> selector) => default;
 
-        /// <summary>
-        /// An account on GitHub, with one or more owners, that has repositories, members and teams.
-        /// </summary>
-        public Organization Organization => this.CreateProperty(x => x.Organization, Octokit.GraphQL.Model.Organization.Create);
+            /// <summary>
+            /// A user is an individual's account on GitHub that owns repositories and can make new content.
+            /// </summary>
+            public Selector<T> User(Func<User, T> selector) => default;
 
-        /// <summary>
-        /// A listing in the GitHub integration marketplace.
-        /// </summary>
-        public MarketplaceListing MarketplaceListing => this.CreateProperty(x => x.MarketplaceListing, Octokit.GraphQL.Model.MarketplaceListing.Create);
+            /// <summary>
+            /// An account on GitHub, with one or more owners, that has repositories, members and teams.
+            /// </summary>
+            public Selector<T> Organization(Func<Organization, T> selector) => default;
+
+            /// <summary>
+            /// A listing in the GitHub integration marketplace.
+            /// </summary>
+            public Selector<T> MarketplaceListing(Func<MarketplaceListing, T> selector) => default;
+        }
 
         internal static SearchResultItem Create(Expression expression)
         {

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -8,4 +8,5 @@
 4. [Variables](variables.md)
 5. [Paging](paging.md)
 5. [Fragments](fragments.md)
-6. [Contributing](contributing.md)
+6. [Unions](unions.md)
+7. [Contributing](contributing.md)

--- a/docs/unions.md
+++ b/docs/unions.md
@@ -1,0 +1,50 @@
+# Unions
+
+GraphQL union types have a single method on then: `Switch` which is used to select a model
+depending on the type returned in the query data. For example, the `IssueOrPullRequest` type
+can contain an issue or a pull request. Supposing we have the following model classes:
+
+```csharp
+class IssueishModel
+{
+    public int Number { get; set; }
+    public string Title { get; set; }
+}
+
+class IssueModel : IssueishModel
+{
+	public bool Closed { get; set; }
+}
+
+class PullRequestModel : IssueishModel
+{
+	public int ChangedFiles { get; set; }
+}
+```
+
+We can use the `Switch` method to select the correct model:
+
+```csharp
+var expression = new Query()
+    .Repository("octokit", "octokit.net")
+    .IssueOrPullRequest(1)
+    .Select(issueOrPr => issueOrPr.Switch<IssueishModel>(when =>
+        when.Issue(issue => new IssueModel
+        {
+            Number = issue.Number,
+			Title = issue.Title,
+			Closed = issue.Closed,
+        }).PullRequest(pr => new PullRequestModel
+        {
+            Number = pr.Number,
+			Title = pr.Title,
+			ChangedFiles = pr.ChangedFiles
+        })));
+```
+
+The generic parameter passed to `Switch<T>` is the type of model to return. In this case,
+`IssueModel` and `PullRequestModel` have a common base class so we can use that. If the models
+don't have a common base class, `object` can be used.
+
+> Note that currently, if a type is returned for which there is no selection in the `Switch`
+  then `null` will be returned. This may change in future.


### PR DESCRIPTION
This PR adds initial support for unions, along with some docs for the feature.

Things that could be added in future:

- Strip out `null` results for types that don't have a match
- Allow using `OfType` or maybe even a simple cast for queries where the type of the result is known (e.g. for `Query.Search`)