### PR TITLE
Fix failing tests

### DIFF
--- a/Octokit.GraphQL.IntegrationTests/Octokit.GraphQL.IntegrationTests.v3.ncrunchproject
+++ b/Octokit.GraphQL.IntegrationTests/Octokit.GraphQL.IntegrationTests.v3.ncrunchproject
@@ -1,5 +1,6 @@
 ﻿<ProjectConfiguration>
   <Settings>
+    <DefaultTestTimeout>15000</DefaultTestTimeout>
     <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
   </Settings>
 </ProjectConfiguration>

--- a/Octokit.GraphQL.IntegrationTests/Queries/RepositoryTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/RepositoryTests.cs
@@ -285,7 +285,7 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
                 });
 
             var testModelObject = await Connection.Run(query);
-            Assert.Equal("alanjrogers", testModelObject.Member.StringField1);
+            Assert.Equal("bkeepers", testModelObject.Member.StringField1);
             Assert.Equal("bkeepers", testModelObject.MentionableUser.StringField1);
         }
 

--- a/Octokit.GraphQL.IntegrationTests/Queries/ViewerTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/ViewerTests.cs
@@ -53,8 +53,8 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
             Assert.NotNull(graphqlUser);
 
             Assert.Equal(apiUser.AvatarUrl, graphqlUser.AvatarUrl);
-            Assert.Equal(apiUser.Bio, graphqlUser.Bio);
-            Assert.Equal(apiUser.Company, graphqlUser.Company);
+            Assert.Equal(apiUser.Bio ?? string.Empty, graphqlUser.Bio);
+            Assert.Equal(apiUser.Company ?? string.Empty, graphqlUser.Company);
 
             Assert.Equal(apiUser.CreatedAt.ToUniversalTime(), graphqlUser.CreatedAt.ToUniversalTime());
 


### PR DESCRIPTION
`Query_Organization_Repositories_Select_Multiple_Object_Fragments` probably isn't a good test as it's querying information that may change over time.