### PR TITLE
Fix fragments on interfaces

### DIFF
--- a/Octokit.GraphQL.Core.UnitTests/Models/Query.cs
+++ b/Octokit.GraphQL.Core.UnitTests/Models/Query.cs
@@ -15,6 +15,7 @@ namespace Octokit.GraphQL.Core.UnitTests.Models
         public IQueryableList<INode> Nodes(Arg<IEnumerable<ID>> ids) => this.CreateMethodCall(x => x.Nodes(ids));
         public RateLimit RateLimit(Arg<bool>? dryRun = null) => this.CreateMethodCall(x => x.RateLimit(dryRun), Models.RateLimit.Create);
         public Repository Repository(Arg<string> owner, Arg<string> name) => this.CreateMethodCall(x => x.Repository(owner, name), Models.Repository.Create);
+        public IRepositoryOwner RepositoryOwner(Arg<string> login) => this.CreateMethodCall(x => x.RepositoryOwner(login), Models.StubIRepositoryOwner.Create);
 
         // Mutations here for convenience.
         public IssueComment AddComment(Arg<AddCommentInput> input) => this.CreateMethodCall(x => x.AddComment(input), Models.IssueComment.Create);

--- a/Octokit.GraphQL.Core.UnitTests/Models/RepositoryConnection.cs
+++ b/Octokit.GraphQL.Core.UnitTests/Models/RepositoryConnection.cs
@@ -1,0 +1,42 @@
+using System.Linq.Expressions;
+using Octokit.GraphQL.Core.Builders;
+
+namespace Octokit.GraphQL.Core.UnitTests.Models
+{
+    /// <summary>
+    /// A list of repositories owned by the subject.
+    /// </summary>
+    public class RepositoryConnection : QueryableValue<RepositoryConnection>, IPagingConnection<Repository>
+    {
+        public RepositoryConnection(Expression expression) : base(expression)
+        {
+        }
+
+        /// <summary>
+        /// A list of nodes.
+        /// </summary>
+        public IQueryableList<Repository> Nodes => this.CreateProperty(x => x.Nodes);
+
+        /// <summary>
+        /// Information to aid in pagination.
+        /// </summary>
+        public PageInfo PageInfo => this.CreateProperty(x => x.PageInfo, Models.PageInfo.Create);
+
+        /// <summary>
+        /// Identifies the total count of items in the connection.
+        /// </summary>
+        public int TotalCount { get; }
+
+        /// <summary>
+        /// The total size in kilobytes of all repositories in the connection.
+        /// </summary>
+        public int TotalDiskUsage { get; }
+
+        IPageInfo IPagingConnection.PageInfo => PageInfo;
+
+        internal static RepositoryConnection Create(Expression expression)
+        {
+            return new RepositoryConnection(expression);
+        }
+    }
+}

--- a/Octokit.GraphQL.Core.UnitTests/Models/RepositoryOwner.cs
+++ b/Octokit.GraphQL.Core.UnitTests/Models/RepositoryOwner.cs
@@ -1,0 +1,56 @@
+using System.Linq.Expressions;
+using Octokit.GraphQL.Core.Builders;
+
+namespace Octokit.GraphQL.Core.UnitTests.Models
+{
+    public interface IRepositoryOwner : IQueryableValue<IRepositoryOwner>, IQueryableInterface
+    {
+        ID Id { get; }
+        string Login { get; }
+
+        RepositoryConnection Repositories(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null);
+
+        /// <summary>
+        /// Find Repository.
+        /// </summary>
+        /// <param name="name">Name of Repository to find.</param>
+        Repository Repository(Arg<string> name);
+
+        /// <summary>
+        /// The HTTP URL for the owner.
+        /// </summary>
+        string ResourcePath { get; }
+
+        /// <summary>
+        /// The HTTP URL for the owner.
+        /// </summary>
+        string Url { get; }
+    }
+}
+
+namespace Octokit.GraphQL.Core.UnitTests.Models
+{
+    internal class StubIRepositoryOwner : QueryableValue<StubIRepositoryOwner>, IRepositoryOwner
+    {
+        public StubIRepositoryOwner(Expression expression) : base(expression)
+        {
+        }
+
+        public ID Id { get; }
+
+        public string Login { get; }
+
+        public RepositoryConnection Repositories(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Repositories(first, after, last, before), Models.RepositoryConnection.Create);
+
+        public Repository Repository(Arg<string> name) => this.CreateMethodCall(x => x.Repository(name), Models.Repository.Create);
+
+        public string ResourcePath { get; }
+
+        public string Url { get; }
+
+        internal static StubIRepositoryOwner Create(Expression expression)
+        {
+            return new StubIRepositoryOwner(expression);
+        }
+    }
+}

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -665,6 +665,29 @@ fragment repositoryName on Repository {
         }
 
         [Fact]
+        public void RepositoryOwner_Select_Simple_Fragment()
+        {
+            var expected = @"query {
+  repositoryOwner(login: ""foo"") {
+    ...ownerLogin
+  }
+}
+fragment ownerLogin on RepositoryOwner {
+  login
+}";
+
+            var fragment = new Fragment<IRepositoryOwner, string>("ownerLogin", owner => owner.Login);
+
+            var expression = new Query()
+                .RepositoryOwner(login: "foo")
+                .Select(fragment);
+
+            var query = expression.Compile();
+
+            Assert.Equal(expected, query.ToString(2), ignoreLineEndingDifferences: true);
+        }
+
+        [Fact]
         public void Repository_Select_Object()
         {
             var expected = @"query {

--- a/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
@@ -369,7 +369,7 @@ namespace Octokit.GraphQL.Core.Builders
                 return Expression.Call(
                     Rewritten.Value.OfTypeMethod,
                     source,
-                    Expression.Constant(fragment.TypeCondition.Name));
+                    Expression.Constant(fragment.TypeCondition));
             }
             else if (IsQueryableValueMember(node.Member))
             {
@@ -847,7 +847,7 @@ namespace Octokit.GraphQL.Core.Builders
                 return Expression.Call(
                     Rewritten.List.OfTypeMethod,
                     instance,
-                    Expression.Constant(fragment.TypeCondition.Name));
+                    Expression.Constant(fragment.TypeCondition));
             }
             else
             {
@@ -867,7 +867,7 @@ namespace Octokit.GraphQL.Core.Builders
                 return Expression.Call(
                     Rewritten.Interface.CastMethod,
                     instance,
-                    Expression.Constant(fragment.TypeCondition.Name));
+                    Expression.Constant(fragment.TypeCondition));
             }
             else
             {

--- a/Octokit.GraphQL.Core/Core/Serializers/QuerySerializer.cs
+++ b/Octokit.GraphQL.Core/Core/Serializers/QuerySerializer.cs
@@ -85,7 +85,7 @@ namespace Octokit.GraphQL.Core.Serializers
             builder.Append("fragment ");
             builder.Append(fragment.Name);
             builder.Append(" on ");
-            builder.Append(fragment.Type);
+            builder.Append(fragment.TypeCondition);
             SerializeSelections(fragment, builder);
         }
 
@@ -124,7 +124,7 @@ namespace Octokit.GraphQL.Core.Serializers
         private void Serialize(InlineFragment fragment, StringBuilder builder)
         {
             builder.Append("... on ");
-            builder.Append(fragment.TypeCondition.Name);
+            builder.Append(fragment.TypeCondition);
 
             if (fragment.Selections.Any() == true)
             {

--- a/Octokit.GraphQL.Core/Core/Syntax/FragmentDefinition.cs
+++ b/Octokit.GraphQL.Core/Core/Syntax/FragmentDefinition.cs
@@ -4,22 +4,20 @@ using System.Text;
 
 namespace Octokit.GraphQL.Core.Syntax
 {
-    public class FragmentDefinition: SelectionSet
+    public class FragmentDefinition : SelectionSet
     {
-        public string Type { get; }
+        public string TypeCondition { get; }
         public string Name { get; }
 
-        public FragmentDefinition(Type inputType, string name)
+        public FragmentDefinition(Type typeCondition, string name)
         {
             if (name.ToLowerInvariant() == "on")
             {
-                throw new ArgumentException("On is an invalid value a fragment name", nameof(name));
+                throw new ArgumentException("'on' is an invalid fragment name", nameof(name));
             }
 
-            Type = ToTypeName(inputType);
+            TypeCondition = GetIdentifier(typeCondition);
             Name = name;
         }
-
-        private string ToTypeName(Type type) => type.Name;
     }
 }

--- a/Octokit.GraphQL.Core/Core/Syntax/InlineFragment.cs
+++ b/Octokit.GraphQL.Core/Core/Syntax/InlineFragment.cs
@@ -7,9 +7,9 @@ namespace Octokit.GraphQL.Core.Syntax
     {
         public InlineFragment(Type typeCondition)
         {
-            TypeCondition = typeCondition;
+            TypeCondition = GetIdentifier(typeCondition);
         }
 
-        public Type TypeCondition { get; }
+        public string TypeCondition { get; }
     }
 }

--- a/Octokit.GraphQL.Core/Core/Syntax/SelectionSet.cs
+++ b/Octokit.GraphQL.Core/Core/Syntax/SelectionSet.cs
@@ -21,5 +21,23 @@ namespace Octokit.GraphQL.Core.Syntax
             var attr = member?.GetCustomAttribute<GraphQLIdentifierAttribute>();
             return attr != null ? attr.Identifier : member?.Name.LowerFirstCharacter();
         }
+
+        public static string GetIdentifier(Type type)
+        {
+            var attr = type.GetTypeInfo().GetCustomAttribute<GraphQLIdentifierAttribute>();
+            
+            if (attr != null)
+            {
+                return attr.Identifier;
+            }
+            else if (type.GetTypeInfo().IsInterface)
+            {
+                return type.Name.Substring(1);
+            }
+            else
+            {
+                return type.Name;
+            }
+        }
     }
 }

--- a/Octokit.GraphQL.IntegrationTests/Queries/RepositoryTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/RepositoryTests.cs
@@ -335,6 +335,52 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
             Assert.True(result.StringList2.Count > 500);
         }
 
+        [IntegrationTest(Skip = "Casts to interface types currently fail")]
+        public async Task Should_Query_RepositoryOwner_Repositories()
+        {
+            var query = new Query()
+                .RepositoryOwner(login: Var("owner"))
+                .Repositories()
+                .AllPages()
+                .Select(repository => repository.Name)
+                .Compile();
+
+            var vars = new Dictionary<string, object>
+            {
+                { "owner", "dotnet" },
+            };
+
+            var result = await Connection.Run(query, vars);
+
+            Assert.True(result.Count() > 2);
+        }
+
+        [IntegrationTest]
+        public async Task Should_Query_RepositoryOwner_Repository_With_Fragment()
+        {
+            var fragment = new Fragment<IRepositoryOwner, OwnerModel>(
+                "OwnerFragment", o =>
+                new OwnerModel()
+                {
+                    Login = o.Login,
+                    AvatarUrl = o.AvatarUrl(100),
+                    Url = o.Url,
+                });
+
+            var query = new Query().Select(q => new
+            {
+                repoOwner = q
+                    .Repository("octokit.net", "octokit")
+                    .Owner
+                    .Select(fragment)
+                    .SingleOrDefault()
+            }).Compile();
+
+            var result = await Connection.Run(query);
+
+            Assert.NotNull(result.repoOwner);
+        }
+
         [IntegrationTest(Skip = "Querying unions like this no longer works")]
         public async Task Should_Query_Union_Issue_Or_PullRequest()
         {
@@ -356,6 +402,13 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
             public string StringField2;
             public int IntField1;
             public int IntField2;
+        }
+
+        public class OwnerModel
+        {
+            public string Login { get; set; }
+            public string Url { get; set; }
+            public string AvatarUrl { get; set; }
         }
     }
 }


### PR DESCRIPTION
We need to strip the `I` from the names of interface types as they aren't present in GraphQL, only in the C# types.

Also slipped in another skipped test demonstrating another interface-related problem.

Fixes #165 
Depends on #169 

cc: @zgorcsos 