### PR TITLE
Being sure to encode ampersands

### DIFF
--- a/Octokit.GraphQL.Core.Generation.UnitTests/EntityGenerationTests.cs
+++ b/Octokit.GraphQL.Core.Generation.UnitTests/EntityGenerationTests.cs
@@ -1636,7 +1636,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         public void Generates_Doc_Comments_For_Property_With_XmlCharacters()
         {
             var expected = FormatMemberTemplate(@"/// <summary>
-        /// Testing if doc comments are generated &lt;http://localhost&gt;.
+        /// Testing if doc comments &amp; generated &lt;http://localhost&gt;.
         /// </summary>
         public Other Foo => this.CreateProperty(x => x.Foo, Test.Other.Create);");
 
@@ -1649,7 +1649,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
                     new FieldModel
                     {
                         Name = "Foo",
-                        Description = "Testing if doc comments are generated <http://localhost>.",
+                        Description = "Testing if doc comments & generated <http://localhost>.",
                         Type = TypeModel.Object("Other")
                     },
                 }

--- a/Octokit.GraphQL.Core.Generation/DocCommentGenerator.cs
+++ b/Octokit.GraphQL.Core.Generation/DocCommentGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using System.Xml;
 
 namespace Octokit.GraphQL.Core.Generation
 {
@@ -20,7 +21,7 @@ namespace Octokit.GraphQL.Core.Generation
 
         private static void GenerateCommentBlock(string text, string indent, StringBuilder builder)
         {
-            text = text.Replace("<", "&lt;").Replace(">", "&gt;");
+            text = text.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
 
             foreach (var line in text.Split('\r', '\n'))
             {


### PR DESCRIPTION
http://xml.silmaril.ie/specials.html

So since it's only XML, there are only 5 characters to account for.
Since we are never inserting this content into an attribute, only tags, we can exclude 2 characters.

Adding anything more complicated than this just isn't worth it.

Fixes #180 