### PR TITLE
Making QueryableValue Expression based constructor internal

### DIFF
--- a/Octokit.GraphQL.Core.Generation.UnitTests/EntityGenerationTests.cs
+++ b/Octokit.GraphQL.Core.Generation.UnitTests/EntityGenerationTests.cs
@@ -19,7 +19,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
 
     public class Entity : QueryableValue<Entity>{1}
     {{
-        public Entity(Expression expression) : base(expression)
+        internal Entity(Expression expression) : base(expression)
         {{
         }}
 {0}
@@ -1538,7 +1538,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
     /// </summary>
     public class Entity : QueryableValue<Entity>
     {
-        public Entity(Expression expression) : base(expression)
+        internal Entity(Expression expression) : base(expression)
         {
         }
 
@@ -1580,7 +1580,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
     /// </summary>
     public class Entity : QueryableValue<Entity>
     {
-        public Entity(Expression expression) : base(expression)
+        internal Entity(Expression expression) : base(expression)
         {
         }
 
@@ -1770,7 +1770,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         {
         }
 
-        public Entity(Expression expression) : base(expression)
+        internal Entity(Expression expression) : base(expression)
         {
         }
 
@@ -1819,7 +1819,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         {
         }
 
-        public Mutation(Expression expression) : base(expression)
+        internal Mutation(Expression expression) : base(expression)
         {
         }
 
@@ -1888,7 +1888,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
 
     public class PageInfo : QueryableValue<PageInfo>, IPageInfo
     {
-        public PageInfo(Expression expression) : base(expression)
+        internal PageInfo(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL.Core.Generation.UnitTests/InterfaceGenerationTests.cs
+++ b/Octokit.GraphQL.Core.Generation.UnitTests/InterfaceGenerationTests.cs
@@ -34,7 +34,7 @@ namespace Test.Internal
 
     internal class StubIEntity : QueryableValue<StubIEntity>, IEntity
     {{
-        public StubIEntity(Expression expression) : base(expression)
+        internal StubIEntity(Expression expression) : base(expression)
         {{
         }}
 {1}
@@ -709,7 +709,7 @@ namespace Test.Internal
     /// </summary>
     public class Entity : QueryableValue<Entity>
     {
-        public Entity(Expression expression) : base(expression)
+        internal Entity(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL.Core.Generation.UnitTests/UnionGenerationTests.cs
+++ b/Octokit.GraphQL.Core.Generation.UnitTests/UnionGenerationTests.cs
@@ -18,7 +18,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
 
     public class Union : QueryableValue<Union>, IUnion
     {{
-        public Union(Expression expression) : base(expression)
+        internal Union(Expression expression) : base(expression)
         {{
         }}
 

--- a/Octokit.GraphQL.Core.Generation/EntityGenerator.cs
+++ b/Octokit.GraphQL.Core.Generation/EntityGenerator.cs
@@ -31,7 +31,7 @@ namespace Octokit.GraphQL.Core.Generation
 
     {GenerateDocComments(type, generateDocComments)}{modifiers}class {className} : QueryableValue<{className}>{GenerateImplementedInterfaces(type, pagingConnectionNodeType)}
     {{
-        public {className}(Expression expression) : base(expression)
+        internal {className}(Expression expression) : base(expression)
         {{
         }}{GenerateFields(type, generateDocComments, rootNamespace, entityNamespace, queryType, pagingConnectionNodeType != null)}
 
@@ -64,7 +64,7 @@ namespace Octokit.GraphQL.Core.Generation
         {{
         }}
 
-        public {className}(Expression expression) : base(expression)
+        internal {className}(Expression expression) : base(expression)
         {{
         }}{GenerateFields(type, true, rootNamespace, entityNamespace, queryType, false)}
 

--- a/Octokit.GraphQL.Core.Generation/UnionGenerator.cs
+++ b/Octokit.GraphQL.Core.Generation/UnionGenerator.cs
@@ -23,7 +23,7 @@ namespace Octokit.GraphQL.Core.Generation
 
     {GenerateUnionDocComments(type)}public class {className} : QueryableValue<{className}>, IUnion
     {{
-        public {className}(Expression expression) : base(expression)
+        internal {className}(Expression expression) : base(expression)
         {{
         }}
 

--- a/Octokit.GraphQL/Model/AcceptTopicSuggestionPayload.cs
+++ b/Octokit.GraphQL/Model/AcceptTopicSuggestionPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class AcceptTopicSuggestionPayload : QueryableValue<AcceptTopicSuggestionPayload>
     {
-        public AcceptTopicSuggestionPayload(Expression expression) : base(expression)
+        internal AcceptTopicSuggestionPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Actor.cs
+++ b/Octokit.GraphQL/Model/Actor.cs
@@ -46,7 +46,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubIActor : QueryableValue<StubIActor>, IActor
     {
-        public StubIActor(Expression expression) : base(expression)
+        internal StubIActor(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/AddCommentPayload.cs
+++ b/Octokit.GraphQL/Model/AddCommentPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class AddCommentPayload : QueryableValue<AddCommentPayload>
     {
-        public AddCommentPayload(Expression expression) : base(expression)
+        internal AddCommentPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/AddProjectCardPayload.cs
+++ b/Octokit.GraphQL/Model/AddProjectCardPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class AddProjectCardPayload : QueryableValue<AddProjectCardPayload>
     {
-        public AddProjectCardPayload(Expression expression) : base(expression)
+        internal AddProjectCardPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/AddProjectColumnPayload.cs
+++ b/Octokit.GraphQL/Model/AddProjectColumnPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class AddProjectColumnPayload : QueryableValue<AddProjectColumnPayload>
     {
-        public AddProjectColumnPayload(Expression expression) : base(expression)
+        internal AddProjectColumnPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/AddPullRequestReviewCommentPayload.cs
+++ b/Octokit.GraphQL/Model/AddPullRequestReviewCommentPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class AddPullRequestReviewCommentPayload : QueryableValue<AddPullRequestReviewCommentPayload>
     {
-        public AddPullRequestReviewCommentPayload(Expression expression) : base(expression)
+        internal AddPullRequestReviewCommentPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/AddPullRequestReviewPayload.cs
+++ b/Octokit.GraphQL/Model/AddPullRequestReviewPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class AddPullRequestReviewPayload : QueryableValue<AddPullRequestReviewPayload>
     {
-        public AddPullRequestReviewPayload(Expression expression) : base(expression)
+        internal AddPullRequestReviewPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/AddReactionPayload.cs
+++ b/Octokit.GraphQL/Model/AddReactionPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class AddReactionPayload : QueryableValue<AddReactionPayload>
     {
-        public AddReactionPayload(Expression expression) : base(expression)
+        internal AddReactionPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/AddStarPayload.cs
+++ b/Octokit.GraphQL/Model/AddStarPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class AddStarPayload : QueryableValue<AddStarPayload>
     {
-        public AddStarPayload(Expression expression) : base(expression)
+        internal AddStarPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/AddedToProjectEvent.cs
+++ b/Octokit.GraphQL/Model/AddedToProjectEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class AddedToProjectEvent : QueryableValue<AddedToProjectEvent>
     {
-        public AddedToProjectEvent(Expression expression) : base(expression)
+        internal AddedToProjectEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/App.cs
+++ b/Octokit.GraphQL/Model/App.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class App : QueryableValue<App>
     {
-        public App(Expression expression) : base(expression)
+        internal App(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/AppEdge.cs
+++ b/Octokit.GraphQL/Model/AppEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class AppEdge : QueryableValue<AppEdge>
     {
-        public AppEdge(Expression expression) : base(expression)
+        internal AppEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Assignable.cs
+++ b/Octokit.GraphQL/Model/Assignable.cs
@@ -34,7 +34,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubIAssignable : QueryableValue<StubIAssignable>, IAssignable
     {
-        public StubIAssignable(Expression expression) : base(expression)
+        internal StubIAssignable(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/AssignedEvent.cs
+++ b/Octokit.GraphQL/Model/AssignedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class AssignedEvent : QueryableValue<AssignedEvent>
     {
-        public AssignedEvent(Expression expression) : base(expression)
+        internal AssignedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/BaseRefChangedEvent.cs
+++ b/Octokit.GraphQL/Model/BaseRefChangedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class BaseRefChangedEvent : QueryableValue<BaseRefChangedEvent>
     {
-        public BaseRefChangedEvent(Expression expression) : base(expression)
+        internal BaseRefChangedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/BaseRefForcePushedEvent.cs
+++ b/Octokit.GraphQL/Model/BaseRefForcePushedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class BaseRefForcePushedEvent : QueryableValue<BaseRefForcePushedEvent>
     {
-        public BaseRefForcePushedEvent(Expression expression) : base(expression)
+        internal BaseRefForcePushedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Blame.cs
+++ b/Octokit.GraphQL/Model/Blame.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Blame : QueryableValue<Blame>
     {
-        public Blame(Expression expression) : base(expression)
+        internal Blame(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/BlameRange.cs
+++ b/Octokit.GraphQL/Model/BlameRange.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class BlameRange : QueryableValue<BlameRange>
     {
-        public BlameRange(Expression expression) : base(expression)
+        internal BlameRange(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Blob.cs
+++ b/Octokit.GraphQL/Model/Blob.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Blob : QueryableValue<Blob>
     {
-        public Blob(Expression expression) : base(expression)
+        internal Blob(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Bot.cs
+++ b/Octokit.GraphQL/Model/Bot.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Bot : QueryableValue<Bot>
     {
-        public Bot(Expression expression) : base(expression)
+        internal Bot(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/BranchProtectionRule.cs
+++ b/Octokit.GraphQL/Model/BranchProtectionRule.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class BranchProtectionRule : QueryableValue<BranchProtectionRule>
     {
-        public BranchProtectionRule(Expression expression) : base(expression)
+        internal BranchProtectionRule(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/BranchProtectionRuleConflict.cs
+++ b/Octokit.GraphQL/Model/BranchProtectionRuleConflict.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class BranchProtectionRuleConflict : QueryableValue<BranchProtectionRuleConflict>
     {
-        public BranchProtectionRuleConflict(Expression expression) : base(expression)
+        internal BranchProtectionRuleConflict(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/BranchProtectionRuleConflictConnection.cs
+++ b/Octokit.GraphQL/Model/BranchProtectionRuleConflictConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class BranchProtectionRuleConflictConnection : QueryableValue<BranchProtectionRuleConflictConnection>, IPagingConnection<BranchProtectionRuleConflict>
     {
-        public BranchProtectionRuleConflictConnection(Expression expression) : base(expression)
+        internal BranchProtectionRuleConflictConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/BranchProtectionRuleConflictEdge.cs
+++ b/Octokit.GraphQL/Model/BranchProtectionRuleConflictEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class BranchProtectionRuleConflictEdge : QueryableValue<BranchProtectionRuleConflictEdge>
     {
-        public BranchProtectionRuleConflictEdge(Expression expression) : base(expression)
+        internal BranchProtectionRuleConflictEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/BranchProtectionRuleConnection.cs
+++ b/Octokit.GraphQL/Model/BranchProtectionRuleConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class BranchProtectionRuleConnection : QueryableValue<BranchProtectionRuleConnection>, IPagingConnection<BranchProtectionRule>
     {
-        public BranchProtectionRuleConnection(Expression expression) : base(expression)
+        internal BranchProtectionRuleConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/BranchProtectionRuleEdge.cs
+++ b/Octokit.GraphQL/Model/BranchProtectionRuleEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class BranchProtectionRuleEdge : QueryableValue<BranchProtectionRuleEdge>
     {
-        public BranchProtectionRuleEdge(Expression expression) : base(expression)
+        internal BranchProtectionRuleEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CheckAnnotation.cs
+++ b/Octokit.GraphQL/Model/CheckAnnotation.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CheckAnnotation : QueryableValue<CheckAnnotation>
     {
-        public CheckAnnotation(Expression expression) : base(expression)
+        internal CheckAnnotation(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CheckAnnotationConnection.cs
+++ b/Octokit.GraphQL/Model/CheckAnnotationConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CheckAnnotationConnection : QueryableValue<CheckAnnotationConnection>, IPagingConnection<CheckAnnotation>
     {
-        public CheckAnnotationConnection(Expression expression) : base(expression)
+        internal CheckAnnotationConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CheckAnnotationEdge.cs
+++ b/Octokit.GraphQL/Model/CheckAnnotationEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CheckAnnotationEdge : QueryableValue<CheckAnnotationEdge>
     {
-        public CheckAnnotationEdge(Expression expression) : base(expression)
+        internal CheckAnnotationEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CheckAnnotationPosition.cs
+++ b/Octokit.GraphQL/Model/CheckAnnotationPosition.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CheckAnnotationPosition : QueryableValue<CheckAnnotationPosition>
     {
-        public CheckAnnotationPosition(Expression expression) : base(expression)
+        internal CheckAnnotationPosition(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CheckAnnotationSpan.cs
+++ b/Octokit.GraphQL/Model/CheckAnnotationSpan.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CheckAnnotationSpan : QueryableValue<CheckAnnotationSpan>
     {
-        public CheckAnnotationSpan(Expression expression) : base(expression)
+        internal CheckAnnotationSpan(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CheckRun.cs
+++ b/Octokit.GraphQL/Model/CheckRun.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CheckRun : QueryableValue<CheckRun>
     {
-        public CheckRun(Expression expression) : base(expression)
+        internal CheckRun(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CheckRunConnection.cs
+++ b/Octokit.GraphQL/Model/CheckRunConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CheckRunConnection : QueryableValue<CheckRunConnection>, IPagingConnection<CheckRun>
     {
-        public CheckRunConnection(Expression expression) : base(expression)
+        internal CheckRunConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CheckRunEdge.cs
+++ b/Octokit.GraphQL/Model/CheckRunEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CheckRunEdge : QueryableValue<CheckRunEdge>
     {
-        public CheckRunEdge(Expression expression) : base(expression)
+        internal CheckRunEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CheckSuite.cs
+++ b/Octokit.GraphQL/Model/CheckSuite.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CheckSuite : QueryableValue<CheckSuite>
     {
-        public CheckSuite(Expression expression) : base(expression)
+        internal CheckSuite(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CheckSuiteConnection.cs
+++ b/Octokit.GraphQL/Model/CheckSuiteConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CheckSuiteConnection : QueryableValue<CheckSuiteConnection>, IPagingConnection<CheckSuite>
     {
-        public CheckSuiteConnection(Expression expression) : base(expression)
+        internal CheckSuiteConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CheckSuiteEdge.cs
+++ b/Octokit.GraphQL/Model/CheckSuiteEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CheckSuiteEdge : QueryableValue<CheckSuiteEdge>
     {
-        public CheckSuiteEdge(Expression expression) : base(expression)
+        internal CheckSuiteEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Closable.cs
+++ b/Octokit.GraphQL/Model/Closable.cs
@@ -35,7 +35,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubIClosable : QueryableValue<StubIClosable>, IClosable
     {
-        public StubIClosable(Expression expression) : base(expression)
+        internal StubIClosable(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ClosedEvent.cs
+++ b/Octokit.GraphQL/Model/ClosedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ClosedEvent : QueryableValue<ClosedEvent>
     {
-        public ClosedEvent(Expression expression) : base(expression)
+        internal ClosedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Closer.cs
+++ b/Octokit.GraphQL/Model/Closer.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Closer : QueryableValue<Closer>, IUnion
     {
-        public Closer(Expression expression) : base(expression)
+        internal Closer(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CodeOfConduct.cs
+++ b/Octokit.GraphQL/Model/CodeOfConduct.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CodeOfConduct : QueryableValue<CodeOfConduct>
     {
-        public CodeOfConduct(Expression expression) : base(expression)
+        internal CodeOfConduct(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CollectionItemContent.cs
+++ b/Octokit.GraphQL/Model/CollectionItemContent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CollectionItemContent : QueryableValue<CollectionItemContent>, IUnion
     {
-        public CollectionItemContent(Expression expression) : base(expression)
+        internal CollectionItemContent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Comment.cs
+++ b/Octokit.GraphQL/Model/Comment.cs
@@ -101,7 +101,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubIComment : QueryableValue<StubIComment>, IComment
     {
-        public StubIComment(Expression expression) : base(expression)
+        internal StubIComment(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CommentDeletedEvent.cs
+++ b/Octokit.GraphQL/Model/CommentDeletedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CommentDeletedEvent : QueryableValue<CommentDeletedEvent>
     {
-        public CommentDeletedEvent(Expression expression) : base(expression)
+        internal CommentDeletedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Commit.cs
+++ b/Octokit.GraphQL/Model/Commit.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Commit : QueryableValue<Commit>
     {
-        public Commit(Expression expression) : base(expression)
+        internal Commit(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CommitComment.cs
+++ b/Octokit.GraphQL/Model/CommitComment.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CommitComment : QueryableValue<CommitComment>
     {
-        public CommitComment(Expression expression) : base(expression)
+        internal CommitComment(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CommitCommentConnection.cs
+++ b/Octokit.GraphQL/Model/CommitCommentConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CommitCommentConnection : QueryableValue<CommitCommentConnection>, IPagingConnection<CommitComment>
     {
-        public CommitCommentConnection(Expression expression) : base(expression)
+        internal CommitCommentConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CommitCommentEdge.cs
+++ b/Octokit.GraphQL/Model/CommitCommentEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CommitCommentEdge : QueryableValue<CommitCommentEdge>
     {
-        public CommitCommentEdge(Expression expression) : base(expression)
+        internal CommitCommentEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CommitCommentThread.cs
+++ b/Octokit.GraphQL/Model/CommitCommentThread.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CommitCommentThread : QueryableValue<CommitCommentThread>
     {
-        public CommitCommentThread(Expression expression) : base(expression)
+        internal CommitCommentThread(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CommitConnection.cs
+++ b/Octokit.GraphQL/Model/CommitConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CommitConnection : QueryableValue<CommitConnection>, IPagingConnection<Commit>
     {
-        public CommitConnection(Expression expression) : base(expression)
+        internal CommitConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CommitEdge.cs
+++ b/Octokit.GraphQL/Model/CommitEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CommitEdge : QueryableValue<CommitEdge>
     {
-        public CommitEdge(Expression expression) : base(expression)
+        internal CommitEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CommitHistoryConnection.cs
+++ b/Octokit.GraphQL/Model/CommitHistoryConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CommitHistoryConnection : QueryableValue<CommitHistoryConnection>, IPagingConnection<Commit>
     {
-        public CommitHistoryConnection(Expression expression) : base(expression)
+        internal CommitHistoryConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ContentAttachment.cs
+++ b/Octokit.GraphQL/Model/ContentAttachment.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ContentAttachment : QueryableValue<ContentAttachment>
     {
-        public ContentAttachment(Expression expression) : base(expression)
+        internal ContentAttachment(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ContentReference.cs
+++ b/Octokit.GraphQL/Model/ContentReference.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ContentReference : QueryableValue<ContentReference>
     {
-        public ContentReference(Expression expression) : base(expression)
+        internal ContentReference(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ContributionCalendar.cs
+++ b/Octokit.GraphQL/Model/ContributionCalendar.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ContributionCalendar : QueryableValue<ContributionCalendar>
     {
-        public ContributionCalendar(Expression expression) : base(expression)
+        internal ContributionCalendar(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ContributionCalendarDay.cs
+++ b/Octokit.GraphQL/Model/ContributionCalendarDay.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ContributionCalendarDay : QueryableValue<ContributionCalendarDay>
     {
-        public ContributionCalendarDay(Expression expression) : base(expression)
+        internal ContributionCalendarDay(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ContributionCalendarMonth.cs
+++ b/Octokit.GraphQL/Model/ContributionCalendarMonth.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ContributionCalendarMonth : QueryableValue<ContributionCalendarMonth>
     {
-        public ContributionCalendarMonth(Expression expression) : base(expression)
+        internal ContributionCalendarMonth(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ContributionCalendarWeek.cs
+++ b/Octokit.GraphQL/Model/ContributionCalendarWeek.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ContributionCalendarWeek : QueryableValue<ContributionCalendarWeek>
     {
-        public ContributionCalendarWeek(Expression expression) : base(expression)
+        internal ContributionCalendarWeek(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ContributionsCollection.cs
+++ b/Octokit.GraphQL/Model/ContributionsCollection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ContributionsCollection : QueryableValue<ContributionsCollection>
     {
-        public ContributionsCollection(Expression expression) : base(expression)
+        internal ContributionsCollection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ConvertedNoteToIssueEvent.cs
+++ b/Octokit.GraphQL/Model/ConvertedNoteToIssueEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ConvertedNoteToIssueEvent : QueryableValue<ConvertedNoteToIssueEvent>
     {
-        public ConvertedNoteToIssueEvent(Expression expression) : base(expression)
+        internal ConvertedNoteToIssueEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CreateBranchProtectionRulePayload.cs
+++ b/Octokit.GraphQL/Model/CreateBranchProtectionRulePayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CreateBranchProtectionRulePayload : QueryableValue<CreateBranchProtectionRulePayload>
     {
-        public CreateBranchProtectionRulePayload(Expression expression) : base(expression)
+        internal CreateBranchProtectionRulePayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CreateCheckRunPayload.cs
+++ b/Octokit.GraphQL/Model/CreateCheckRunPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CreateCheckRunPayload : QueryableValue<CreateCheckRunPayload>
     {
-        public CreateCheckRunPayload(Expression expression) : base(expression)
+        internal CreateCheckRunPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CreateCheckSuitePayload.cs
+++ b/Octokit.GraphQL/Model/CreateCheckSuitePayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CreateCheckSuitePayload : QueryableValue<CreateCheckSuitePayload>
     {
-        public CreateCheckSuitePayload(Expression expression) : base(expression)
+        internal CreateCheckSuitePayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CreateProjectPayload.cs
+++ b/Octokit.GraphQL/Model/CreateProjectPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CreateProjectPayload : QueryableValue<CreateProjectPayload>
     {
-        public CreateProjectPayload(Expression expression) : base(expression)
+        internal CreateProjectPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/CrossReferencedEvent.cs
+++ b/Octokit.GraphQL/Model/CrossReferencedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class CrossReferencedEvent : QueryableValue<CrossReferencedEvent>
     {
-        public CrossReferencedEvent(Expression expression) : base(expression)
+        internal CrossReferencedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/DeclineTopicSuggestionPayload.cs
+++ b/Octokit.GraphQL/Model/DeclineTopicSuggestionPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class DeclineTopicSuggestionPayload : QueryableValue<DeclineTopicSuggestionPayload>
     {
-        public DeclineTopicSuggestionPayload(Expression expression) : base(expression)
+        internal DeclineTopicSuggestionPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Deletable.cs
+++ b/Octokit.GraphQL/Model/Deletable.cs
@@ -30,7 +30,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubIDeletable : QueryableValue<StubIDeletable>, IDeletable
     {
-        public StubIDeletable(Expression expression) : base(expression)
+        internal StubIDeletable(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/DeleteBranchProtectionRulePayload.cs
+++ b/Octokit.GraphQL/Model/DeleteBranchProtectionRulePayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class DeleteBranchProtectionRulePayload : QueryableValue<DeleteBranchProtectionRulePayload>
     {
-        public DeleteBranchProtectionRulePayload(Expression expression) : base(expression)
+        internal DeleteBranchProtectionRulePayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/DeleteProjectCardPayload.cs
+++ b/Octokit.GraphQL/Model/DeleteProjectCardPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class DeleteProjectCardPayload : QueryableValue<DeleteProjectCardPayload>
     {
-        public DeleteProjectCardPayload(Expression expression) : base(expression)
+        internal DeleteProjectCardPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/DeleteProjectColumnPayload.cs
+++ b/Octokit.GraphQL/Model/DeleteProjectColumnPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class DeleteProjectColumnPayload : QueryableValue<DeleteProjectColumnPayload>
     {
-        public DeleteProjectColumnPayload(Expression expression) : base(expression)
+        internal DeleteProjectColumnPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/DeleteProjectPayload.cs
+++ b/Octokit.GraphQL/Model/DeleteProjectPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class DeleteProjectPayload : QueryableValue<DeleteProjectPayload>
     {
-        public DeleteProjectPayload(Expression expression) : base(expression)
+        internal DeleteProjectPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/DeletePullRequestReviewPayload.cs
+++ b/Octokit.GraphQL/Model/DeletePullRequestReviewPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class DeletePullRequestReviewPayload : QueryableValue<DeletePullRequestReviewPayload>
     {
-        public DeletePullRequestReviewPayload(Expression expression) : base(expression)
+        internal DeletePullRequestReviewPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/DemilestonedEvent.cs
+++ b/Octokit.GraphQL/Model/DemilestonedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class DemilestonedEvent : QueryableValue<DemilestonedEvent>
     {
-        public DemilestonedEvent(Expression expression) : base(expression)
+        internal DemilestonedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/DeployKey.cs
+++ b/Octokit.GraphQL/Model/DeployKey.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class DeployKey : QueryableValue<DeployKey>
     {
-        public DeployKey(Expression expression) : base(expression)
+        internal DeployKey(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/DeployKeyConnection.cs
+++ b/Octokit.GraphQL/Model/DeployKeyConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class DeployKeyConnection : QueryableValue<DeployKeyConnection>, IPagingConnection<DeployKey>
     {
-        public DeployKeyConnection(Expression expression) : base(expression)
+        internal DeployKeyConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/DeployKeyEdge.cs
+++ b/Octokit.GraphQL/Model/DeployKeyEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class DeployKeyEdge : QueryableValue<DeployKeyEdge>
     {
-        public DeployKeyEdge(Expression expression) : base(expression)
+        internal DeployKeyEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/DeployedEvent.cs
+++ b/Octokit.GraphQL/Model/DeployedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class DeployedEvent : QueryableValue<DeployedEvent>
     {
-        public DeployedEvent(Expression expression) : base(expression)
+        internal DeployedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Deployment.cs
+++ b/Octokit.GraphQL/Model/Deployment.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Deployment : QueryableValue<Deployment>
     {
-        public Deployment(Expression expression) : base(expression)
+        internal Deployment(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/DeploymentConnection.cs
+++ b/Octokit.GraphQL/Model/DeploymentConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class DeploymentConnection : QueryableValue<DeploymentConnection>, IPagingConnection<Deployment>
     {
-        public DeploymentConnection(Expression expression) : base(expression)
+        internal DeploymentConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/DeploymentEdge.cs
+++ b/Octokit.GraphQL/Model/DeploymentEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class DeploymentEdge : QueryableValue<DeploymentEdge>
     {
-        public DeploymentEdge(Expression expression) : base(expression)
+        internal DeploymentEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/DeploymentEnvironmentChangedEvent.cs
+++ b/Octokit.GraphQL/Model/DeploymentEnvironmentChangedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class DeploymentEnvironmentChangedEvent : QueryableValue<DeploymentEnvironmentChangedEvent>
     {
-        public DeploymentEnvironmentChangedEvent(Expression expression) : base(expression)
+        internal DeploymentEnvironmentChangedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/DeploymentStatus.cs
+++ b/Octokit.GraphQL/Model/DeploymentStatus.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class DeploymentStatus : QueryableValue<DeploymentStatus>
     {
-        public DeploymentStatus(Expression expression) : base(expression)
+        internal DeploymentStatus(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/DeploymentStatusConnection.cs
+++ b/Octokit.GraphQL/Model/DeploymentStatusConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class DeploymentStatusConnection : QueryableValue<DeploymentStatusConnection>, IPagingConnection<DeploymentStatus>
     {
-        public DeploymentStatusConnection(Expression expression) : base(expression)
+        internal DeploymentStatusConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/DeploymentStatusEdge.cs
+++ b/Octokit.GraphQL/Model/DeploymentStatusEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class DeploymentStatusEdge : QueryableValue<DeploymentStatusEdge>
     {
-        public DeploymentStatusEdge(Expression expression) : base(expression)
+        internal DeploymentStatusEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/DismissPullRequestReviewPayload.cs
+++ b/Octokit.GraphQL/Model/DismissPullRequestReviewPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class DismissPullRequestReviewPayload : QueryableValue<DismissPullRequestReviewPayload>
     {
-        public DismissPullRequestReviewPayload(Expression expression) : base(expression)
+        internal DismissPullRequestReviewPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ExternalIdentity.cs
+++ b/Octokit.GraphQL/Model/ExternalIdentity.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ExternalIdentity : QueryableValue<ExternalIdentity>
     {
-        public ExternalIdentity(Expression expression) : base(expression)
+        internal ExternalIdentity(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ExternalIdentityConnection.cs
+++ b/Octokit.GraphQL/Model/ExternalIdentityConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ExternalIdentityConnection : QueryableValue<ExternalIdentityConnection>, IPagingConnection<ExternalIdentity>
     {
-        public ExternalIdentityConnection(Expression expression) : base(expression)
+        internal ExternalIdentityConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ExternalIdentityEdge.cs
+++ b/Octokit.GraphQL/Model/ExternalIdentityEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ExternalIdentityEdge : QueryableValue<ExternalIdentityEdge>
     {
-        public ExternalIdentityEdge(Expression expression) : base(expression)
+        internal ExternalIdentityEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ExternalIdentitySamlAttributes.cs
+++ b/Octokit.GraphQL/Model/ExternalIdentitySamlAttributes.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ExternalIdentitySamlAttributes : QueryableValue<ExternalIdentitySamlAttributes>
     {
-        public ExternalIdentitySamlAttributes(Expression expression) : base(expression)
+        internal ExternalIdentitySamlAttributes(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ExternalIdentityScimAttributes.cs
+++ b/Octokit.GraphQL/Model/ExternalIdentityScimAttributes.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ExternalIdentityScimAttributes : QueryableValue<ExternalIdentityScimAttributes>
     {
-        public ExternalIdentityScimAttributes(Expression expression) : base(expression)
+        internal ExternalIdentityScimAttributes(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/FollowerConnection.cs
+++ b/Octokit.GraphQL/Model/FollowerConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class FollowerConnection : QueryableValue<FollowerConnection>, IPagingConnection<User>
     {
-        public FollowerConnection(Expression expression) : base(expression)
+        internal FollowerConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/FollowingConnection.cs
+++ b/Octokit.GraphQL/Model/FollowingConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class FollowingConnection : QueryableValue<FollowingConnection>, IPagingConnection<User>
     {
-        public FollowingConnection(Expression expression) : base(expression)
+        internal FollowingConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Gist.cs
+++ b/Octokit.GraphQL/Model/Gist.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Gist : QueryableValue<Gist>
     {
-        public Gist(Expression expression) : base(expression)
+        internal Gist(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/GistComment.cs
+++ b/Octokit.GraphQL/Model/GistComment.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class GistComment : QueryableValue<GistComment>
     {
-        public GistComment(Expression expression) : base(expression)
+        internal GistComment(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/GistCommentConnection.cs
+++ b/Octokit.GraphQL/Model/GistCommentConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class GistCommentConnection : QueryableValue<GistCommentConnection>, IPagingConnection<GistComment>
     {
-        public GistCommentConnection(Expression expression) : base(expression)
+        internal GistCommentConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/GistCommentEdge.cs
+++ b/Octokit.GraphQL/Model/GistCommentEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class GistCommentEdge : QueryableValue<GistCommentEdge>
     {
-        public GistCommentEdge(Expression expression) : base(expression)
+        internal GistCommentEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/GistConnection.cs
+++ b/Octokit.GraphQL/Model/GistConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class GistConnection : QueryableValue<GistConnection>, IPagingConnection<Gist>
     {
-        public GistConnection(Expression expression) : base(expression)
+        internal GistConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/GistEdge.cs
+++ b/Octokit.GraphQL/Model/GistEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class GistEdge : QueryableValue<GistEdge>
     {
-        public GistEdge(Expression expression) : base(expression)
+        internal GistEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/GitActor.cs
+++ b/Octokit.GraphQL/Model/GitActor.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class GitActor : QueryableValue<GitActor>
     {
-        public GitActor(Expression expression) : base(expression)
+        internal GitActor(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/GitHubMetadata.cs
+++ b/Octokit.GraphQL/Model/GitHubMetadata.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class GitHubMetadata : QueryableValue<GitHubMetadata>
     {
-        public GitHubMetadata(Expression expression) : base(expression)
+        internal GitHubMetadata(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/GitObject.cs
+++ b/Octokit.GraphQL/Model/GitObject.cs
@@ -52,7 +52,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubIGitObject : QueryableValue<StubIGitObject>, IGitObject
     {
-        public StubIGitObject(Expression expression) : base(expression)
+        internal StubIGitObject(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/GitSignature.cs
+++ b/Octokit.GraphQL/Model/GitSignature.cs
@@ -60,7 +60,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubIGitSignature : QueryableValue<StubIGitSignature>, IGitSignature
     {
-        public StubIGitSignature(Expression expression) : base(expression)
+        internal StubIGitSignature(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/GpgSignature.cs
+++ b/Octokit.GraphQL/Model/GpgSignature.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class GpgSignature : QueryableValue<GpgSignature>
     {
-        public GpgSignature(Expression expression) : base(expression)
+        internal GpgSignature(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/HeadRefDeletedEvent.cs
+++ b/Octokit.GraphQL/Model/HeadRefDeletedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class HeadRefDeletedEvent : QueryableValue<HeadRefDeletedEvent>
     {
-        public HeadRefDeletedEvent(Expression expression) : base(expression)
+        internal HeadRefDeletedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/HeadRefForcePushedEvent.cs
+++ b/Octokit.GraphQL/Model/HeadRefForcePushedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class HeadRefForcePushedEvent : QueryableValue<HeadRefForcePushedEvent>
     {
-        public HeadRefForcePushedEvent(Expression expression) : base(expression)
+        internal HeadRefForcePushedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/HeadRefRestoredEvent.cs
+++ b/Octokit.GraphQL/Model/HeadRefRestoredEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class HeadRefRestoredEvent : QueryableValue<HeadRefRestoredEvent>
     {
-        public HeadRefRestoredEvent(Expression expression) : base(expression)
+        internal HeadRefRestoredEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Issue.cs
+++ b/Octokit.GraphQL/Model/Issue.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Issue : QueryableValue<Issue>
     {
-        public Issue(Expression expression) : base(expression)
+        internal Issue(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/IssueComment.cs
+++ b/Octokit.GraphQL/Model/IssueComment.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class IssueComment : QueryableValue<IssueComment>
     {
-        public IssueComment(Expression expression) : base(expression)
+        internal IssueComment(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/IssueCommentConnection.cs
+++ b/Octokit.GraphQL/Model/IssueCommentConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class IssueCommentConnection : QueryableValue<IssueCommentConnection>, IPagingConnection<IssueComment>
     {
-        public IssueCommentConnection(Expression expression) : base(expression)
+        internal IssueCommentConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/IssueCommentEdge.cs
+++ b/Octokit.GraphQL/Model/IssueCommentEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class IssueCommentEdge : QueryableValue<IssueCommentEdge>
     {
-        public IssueCommentEdge(Expression expression) : base(expression)
+        internal IssueCommentEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/IssueConnection.cs
+++ b/Octokit.GraphQL/Model/IssueConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class IssueConnection : QueryableValue<IssueConnection>, IPagingConnection<Issue>
     {
-        public IssueConnection(Expression expression) : base(expression)
+        internal IssueConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/IssueEdge.cs
+++ b/Octokit.GraphQL/Model/IssueEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class IssueEdge : QueryableValue<IssueEdge>
     {
-        public IssueEdge(Expression expression) : base(expression)
+        internal IssueEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/IssueOrPullRequest.cs
+++ b/Octokit.GraphQL/Model/IssueOrPullRequest.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class IssueOrPullRequest : QueryableValue<IssueOrPullRequest>, IUnion
     {
-        public IssueOrPullRequest(Expression expression) : base(expression)
+        internal IssueOrPullRequest(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/IssueTimelineConnection.cs
+++ b/Octokit.GraphQL/Model/IssueTimelineConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class IssueTimelineConnection : QueryableValue<IssueTimelineConnection>, IPagingConnection<IssueTimelineItem>
     {
-        public IssueTimelineConnection(Expression expression) : base(expression)
+        internal IssueTimelineConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/IssueTimelineItem.cs
+++ b/Octokit.GraphQL/Model/IssueTimelineItem.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class IssueTimelineItem : QueryableValue<IssueTimelineItem>, IUnion
     {
-        public IssueTimelineItem(Expression expression) : base(expression)
+        internal IssueTimelineItem(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/IssueTimelineItemEdge.cs
+++ b/Octokit.GraphQL/Model/IssueTimelineItemEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class IssueTimelineItemEdge : QueryableValue<IssueTimelineItemEdge>
     {
-        public IssueTimelineItemEdge(Expression expression) : base(expression)
+        internal IssueTimelineItemEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/IssueTimelineItems.cs
+++ b/Octokit.GraphQL/Model/IssueTimelineItems.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class IssueTimelineItems : QueryableValue<IssueTimelineItems>, IUnion
     {
-        public IssueTimelineItems(Expression expression) : base(expression)
+        internal IssueTimelineItems(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/IssueTimelineItemsEdge.cs
+++ b/Octokit.GraphQL/Model/IssueTimelineItemsEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class IssueTimelineItemsEdge : QueryableValue<IssueTimelineItemsEdge>
     {
-        public IssueTimelineItemsEdge(Expression expression) : base(expression)
+        internal IssueTimelineItemsEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Label.cs
+++ b/Octokit.GraphQL/Model/Label.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Label : QueryableValue<Label>
     {
-        public Label(Expression expression) : base(expression)
+        internal Label(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/LabelConnection.cs
+++ b/Octokit.GraphQL/Model/LabelConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class LabelConnection : QueryableValue<LabelConnection>, IPagingConnection<Label>
     {
-        public LabelConnection(Expression expression) : base(expression)
+        internal LabelConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/LabelEdge.cs
+++ b/Octokit.GraphQL/Model/LabelEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class LabelEdge : QueryableValue<LabelEdge>
     {
-        public LabelEdge(Expression expression) : base(expression)
+        internal LabelEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Labelable.cs
+++ b/Octokit.GraphQL/Model/Labelable.cs
@@ -34,7 +34,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubILabelable : QueryableValue<StubILabelable>, ILabelable
     {
-        public StubILabelable(Expression expression) : base(expression)
+        internal StubILabelable(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/LabeledEvent.cs
+++ b/Octokit.GraphQL/Model/LabeledEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class LabeledEvent : QueryableValue<LabeledEvent>
     {
-        public LabeledEvent(Expression expression) : base(expression)
+        internal LabeledEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Language.cs
+++ b/Octokit.GraphQL/Model/Language.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Language : QueryableValue<Language>
     {
-        public Language(Expression expression) : base(expression)
+        internal Language(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/LanguageConnection.cs
+++ b/Octokit.GraphQL/Model/LanguageConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class LanguageConnection : QueryableValue<LanguageConnection>, IPagingConnection<Language>
     {
-        public LanguageConnection(Expression expression) : base(expression)
+        internal LanguageConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/LanguageEdge.cs
+++ b/Octokit.GraphQL/Model/LanguageEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class LanguageEdge : QueryableValue<LanguageEdge>
     {
-        public LanguageEdge(Expression expression) : base(expression)
+        internal LanguageEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/License.cs
+++ b/Octokit.GraphQL/Model/License.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class License : QueryableValue<License>
     {
-        public License(Expression expression) : base(expression)
+        internal License(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/LicenseRule.cs
+++ b/Octokit.GraphQL/Model/LicenseRule.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class LicenseRule : QueryableValue<LicenseRule>
     {
-        public LicenseRule(Expression expression) : base(expression)
+        internal LicenseRule(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/LockLockablePayload.cs
+++ b/Octokit.GraphQL/Model/LockLockablePayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class LockLockablePayload : QueryableValue<LockLockablePayload>
     {
-        public LockLockablePayload(Expression expression) : base(expression)
+        internal LockLockablePayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Lockable.cs
+++ b/Octokit.GraphQL/Model/Lockable.cs
@@ -35,7 +35,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubILockable : QueryableValue<StubILockable>, ILockable
     {
-        public StubILockable(Expression expression) : base(expression)
+        internal StubILockable(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/LockedEvent.cs
+++ b/Octokit.GraphQL/Model/LockedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class LockedEvent : QueryableValue<LockedEvent>
     {
-        public LockedEvent(Expression expression) : base(expression)
+        internal LockedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/MarketplaceCategory.cs
+++ b/Octokit.GraphQL/Model/MarketplaceCategory.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class MarketplaceCategory : QueryableValue<MarketplaceCategory>
     {
-        public MarketplaceCategory(Expression expression) : base(expression)
+        internal MarketplaceCategory(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/MarketplaceListing.cs
+++ b/Octokit.GraphQL/Model/MarketplaceListing.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class MarketplaceListing : QueryableValue<MarketplaceListing>
     {
-        public MarketplaceListing(Expression expression) : base(expression)
+        internal MarketplaceListing(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/MarketplaceListingConnection.cs
+++ b/Octokit.GraphQL/Model/MarketplaceListingConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class MarketplaceListingConnection : QueryableValue<MarketplaceListingConnection>, IPagingConnection<MarketplaceListing>
     {
-        public MarketplaceListingConnection(Expression expression) : base(expression)
+        internal MarketplaceListingConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/MarketplaceListingEdge.cs
+++ b/Octokit.GraphQL/Model/MarketplaceListingEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class MarketplaceListingEdge : QueryableValue<MarketplaceListingEdge>
     {
-        public MarketplaceListingEdge(Expression expression) : base(expression)
+        internal MarketplaceListingEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/MentionedEvent.cs
+++ b/Octokit.GraphQL/Model/MentionedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class MentionedEvent : QueryableValue<MentionedEvent>
     {
-        public MentionedEvent(Expression expression) : base(expression)
+        internal MentionedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/MergedEvent.cs
+++ b/Octokit.GraphQL/Model/MergedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class MergedEvent : QueryableValue<MergedEvent>
     {
-        public MergedEvent(Expression expression) : base(expression)
+        internal MergedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Milestone.cs
+++ b/Octokit.GraphQL/Model/Milestone.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Milestone : QueryableValue<Milestone>
     {
-        public Milestone(Expression expression) : base(expression)
+        internal Milestone(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/MilestoneConnection.cs
+++ b/Octokit.GraphQL/Model/MilestoneConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class MilestoneConnection : QueryableValue<MilestoneConnection>, IPagingConnection<Milestone>
     {
-        public MilestoneConnection(Expression expression) : base(expression)
+        internal MilestoneConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/MilestoneEdge.cs
+++ b/Octokit.GraphQL/Model/MilestoneEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class MilestoneEdge : QueryableValue<MilestoneEdge>
     {
-        public MilestoneEdge(Expression expression) : base(expression)
+        internal MilestoneEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/MilestoneItem.cs
+++ b/Octokit.GraphQL/Model/MilestoneItem.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class MilestoneItem : QueryableValue<MilestoneItem>, IUnion
     {
-        public MilestoneItem(Expression expression) : base(expression)
+        internal MilestoneItem(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/MilestonedEvent.cs
+++ b/Octokit.GraphQL/Model/MilestonedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class MilestonedEvent : QueryableValue<MilestonedEvent>
     {
-        public MilestonedEvent(Expression expression) : base(expression)
+        internal MilestonedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/MoveProjectCardPayload.cs
+++ b/Octokit.GraphQL/Model/MoveProjectCardPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class MoveProjectCardPayload : QueryableValue<MoveProjectCardPayload>
     {
-        public MoveProjectCardPayload(Expression expression) : base(expression)
+        internal MoveProjectCardPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/MoveProjectColumnPayload.cs
+++ b/Octokit.GraphQL/Model/MoveProjectColumnPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class MoveProjectColumnPayload : QueryableValue<MoveProjectColumnPayload>
     {
-        public MoveProjectColumnPayload(Expression expression) : base(expression)
+        internal MoveProjectColumnPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/MovedColumnsInProjectEvent.cs
+++ b/Octokit.GraphQL/Model/MovedColumnsInProjectEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class MovedColumnsInProjectEvent : QueryableValue<MovedColumnsInProjectEvent>
     {
-        public MovedColumnsInProjectEvent(Expression expression) : base(expression)
+        internal MovedColumnsInProjectEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Node.cs
+++ b/Octokit.GraphQL/Model/Node.cs
@@ -30,7 +30,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubINode : QueryableValue<StubINode>, INode
     {
-        public StubINode(Expression expression) : base(expression)
+        internal StubINode(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Organization.cs
+++ b/Octokit.GraphQL/Model/Organization.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Organization : QueryableValue<Organization>
     {
-        public Organization(Expression expression) : base(expression)
+        internal Organization(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/OrganizationConnection.cs
+++ b/Octokit.GraphQL/Model/OrganizationConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class OrganizationConnection : QueryableValue<OrganizationConnection>, IPagingConnection<Organization>
     {
-        public OrganizationConnection(Expression expression) : base(expression)
+        internal OrganizationConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/OrganizationEdge.cs
+++ b/Octokit.GraphQL/Model/OrganizationEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class OrganizationEdge : QueryableValue<OrganizationEdge>
     {
-        public OrganizationEdge(Expression expression) : base(expression)
+        internal OrganizationEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/OrganizationIdentityProvider.cs
+++ b/Octokit.GraphQL/Model/OrganizationIdentityProvider.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class OrganizationIdentityProvider : QueryableValue<OrganizationIdentityProvider>
     {
-        public OrganizationIdentityProvider(Expression expression) : base(expression)
+        internal OrganizationIdentityProvider(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/OrganizationInvitation.cs
+++ b/Octokit.GraphQL/Model/OrganizationInvitation.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class OrganizationInvitation : QueryableValue<OrganizationInvitation>
     {
-        public OrganizationInvitation(Expression expression) : base(expression)
+        internal OrganizationInvitation(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/OrganizationInvitationConnection.cs
+++ b/Octokit.GraphQL/Model/OrganizationInvitationConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class OrganizationInvitationConnection : QueryableValue<OrganizationInvitationConnection>, IPagingConnection<OrganizationInvitation>
     {
-        public OrganizationInvitationConnection(Expression expression) : base(expression)
+        internal OrganizationInvitationConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/OrganizationInvitationEdge.cs
+++ b/Octokit.GraphQL/Model/OrganizationInvitationEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class OrganizationInvitationEdge : QueryableValue<OrganizationInvitationEdge>
     {
-        public OrganizationInvitationEdge(Expression expression) : base(expression)
+        internal OrganizationInvitationEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/OrganizationMemberConnection.cs
+++ b/Octokit.GraphQL/Model/OrganizationMemberConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class OrganizationMemberConnection : QueryableValue<OrganizationMemberConnection>, IPagingConnection<User>
     {
-        public OrganizationMemberConnection(Expression expression) : base(expression)
+        internal OrganizationMemberConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/OrganizationMemberEdge.cs
+++ b/Octokit.GraphQL/Model/OrganizationMemberEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class OrganizationMemberEdge : QueryableValue<OrganizationMemberEdge>
     {
-        public OrganizationMemberEdge(Expression expression) : base(expression)
+        internal OrganizationMemberEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PageInfo.cs
+++ b/Octokit.GraphQL/Model/PageInfo.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PageInfo : QueryableValue<PageInfo>, IPageInfo
     {
-        public PageInfo(Expression expression) : base(expression)
+        internal PageInfo(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PinnedEvent.cs
+++ b/Octokit.GraphQL/Model/PinnedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PinnedEvent : QueryableValue<PinnedEvent>
     {
-        public PinnedEvent(Expression expression) : base(expression)
+        internal PinnedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Project.cs
+++ b/Octokit.GraphQL/Model/Project.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Project : QueryableValue<Project>
     {
-        public Project(Expression expression) : base(expression)
+        internal Project(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ProjectCard.cs
+++ b/Octokit.GraphQL/Model/ProjectCard.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ProjectCard : QueryableValue<ProjectCard>
     {
-        public ProjectCard(Expression expression) : base(expression)
+        internal ProjectCard(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ProjectCardConnection.cs
+++ b/Octokit.GraphQL/Model/ProjectCardConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ProjectCardConnection : QueryableValue<ProjectCardConnection>, IPagingConnection<ProjectCard>
     {
-        public ProjectCardConnection(Expression expression) : base(expression)
+        internal ProjectCardConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ProjectCardEdge.cs
+++ b/Octokit.GraphQL/Model/ProjectCardEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ProjectCardEdge : QueryableValue<ProjectCardEdge>
     {
-        public ProjectCardEdge(Expression expression) : base(expression)
+        internal ProjectCardEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ProjectCardItem.cs
+++ b/Octokit.GraphQL/Model/ProjectCardItem.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ProjectCardItem : QueryableValue<ProjectCardItem>, IUnion
     {
-        public ProjectCardItem(Expression expression) : base(expression)
+        internal ProjectCardItem(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ProjectColumn.cs
+++ b/Octokit.GraphQL/Model/ProjectColumn.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ProjectColumn : QueryableValue<ProjectColumn>
     {
-        public ProjectColumn(Expression expression) : base(expression)
+        internal ProjectColumn(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ProjectColumnConnection.cs
+++ b/Octokit.GraphQL/Model/ProjectColumnConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ProjectColumnConnection : QueryableValue<ProjectColumnConnection>, IPagingConnection<ProjectColumn>
     {
-        public ProjectColumnConnection(Expression expression) : base(expression)
+        internal ProjectColumnConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ProjectColumnEdge.cs
+++ b/Octokit.GraphQL/Model/ProjectColumnEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ProjectColumnEdge : QueryableValue<ProjectColumnEdge>
     {
-        public ProjectColumnEdge(Expression expression) : base(expression)
+        internal ProjectColumnEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ProjectConnection.cs
+++ b/Octokit.GraphQL/Model/ProjectConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ProjectConnection : QueryableValue<ProjectConnection>, IPagingConnection<Project>
     {
-        public ProjectConnection(Expression expression) : base(expression)
+        internal ProjectConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ProjectEdge.cs
+++ b/Octokit.GraphQL/Model/ProjectEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ProjectEdge : QueryableValue<ProjectEdge>
     {
-        public ProjectEdge(Expression expression) : base(expression)
+        internal ProjectEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ProjectOwner.cs
+++ b/Octokit.GraphQL/Model/ProjectOwner.cs
@@ -60,7 +60,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubIProjectOwner : QueryableValue<StubIProjectOwner>, IProjectOwner
     {
-        public StubIProjectOwner(Expression expression) : base(expression)
+        internal StubIProjectOwner(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ProtectedBranch.cs
+++ b/Octokit.GraphQL/Model/ProtectedBranch.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ProtectedBranch : QueryableValue<ProtectedBranch>
     {
-        public ProtectedBranch(Expression expression) : base(expression)
+        internal ProtectedBranch(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ProtectedBranchConnection.cs
+++ b/Octokit.GraphQL/Model/ProtectedBranchConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ProtectedBranchConnection : QueryableValue<ProtectedBranchConnection>, IPagingConnection<ProtectedBranch>
     {
-        public ProtectedBranchConnection(Expression expression) : base(expression)
+        internal ProtectedBranchConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ProtectedBranchEdge.cs
+++ b/Octokit.GraphQL/Model/ProtectedBranchEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ProtectedBranchEdge : QueryableValue<ProtectedBranchEdge>
     {
-        public ProtectedBranchEdge(Expression expression) : base(expression)
+        internal ProtectedBranchEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PublicKey.cs
+++ b/Octokit.GraphQL/Model/PublicKey.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PublicKey : QueryableValue<PublicKey>
     {
-        public PublicKey(Expression expression) : base(expression)
+        internal PublicKey(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PublicKeyConnection.cs
+++ b/Octokit.GraphQL/Model/PublicKeyConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PublicKeyConnection : QueryableValue<PublicKeyConnection>, IPagingConnection<PublicKey>
     {
-        public PublicKeyConnection(Expression expression) : base(expression)
+        internal PublicKeyConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PublicKeyEdge.cs
+++ b/Octokit.GraphQL/Model/PublicKeyEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PublicKeyEdge : QueryableValue<PublicKeyEdge>
     {
-        public PublicKeyEdge(Expression expression) : base(expression)
+        internal PublicKeyEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PullRequest.cs
+++ b/Octokit.GraphQL/Model/PullRequest.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PullRequest : QueryableValue<PullRequest>
     {
-        public PullRequest(Expression expression) : base(expression)
+        internal PullRequest(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PullRequestCommit.cs
+++ b/Octokit.GraphQL/Model/PullRequestCommit.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PullRequestCommit : QueryableValue<PullRequestCommit>
     {
-        public PullRequestCommit(Expression expression) : base(expression)
+        internal PullRequestCommit(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PullRequestCommitConnection.cs
+++ b/Octokit.GraphQL/Model/PullRequestCommitConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PullRequestCommitConnection : QueryableValue<PullRequestCommitConnection>, IPagingConnection<PullRequestCommit>
     {
-        public PullRequestCommitConnection(Expression expression) : base(expression)
+        internal PullRequestCommitConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PullRequestCommitEdge.cs
+++ b/Octokit.GraphQL/Model/PullRequestCommitEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PullRequestCommitEdge : QueryableValue<PullRequestCommitEdge>
     {
-        public PullRequestCommitEdge(Expression expression) : base(expression)
+        internal PullRequestCommitEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PullRequestConnection.cs
+++ b/Octokit.GraphQL/Model/PullRequestConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PullRequestConnection : QueryableValue<PullRequestConnection>, IPagingConnection<PullRequest>
     {
-        public PullRequestConnection(Expression expression) : base(expression)
+        internal PullRequestConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PullRequestEdge.cs
+++ b/Octokit.GraphQL/Model/PullRequestEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PullRequestEdge : QueryableValue<PullRequestEdge>
     {
-        public PullRequestEdge(Expression expression) : base(expression)
+        internal PullRequestEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PullRequestReview.cs
+++ b/Octokit.GraphQL/Model/PullRequestReview.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PullRequestReview : QueryableValue<PullRequestReview>
     {
-        public PullRequestReview(Expression expression) : base(expression)
+        internal PullRequestReview(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PullRequestReviewComment.cs
+++ b/Octokit.GraphQL/Model/PullRequestReviewComment.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PullRequestReviewComment : QueryableValue<PullRequestReviewComment>
     {
-        public PullRequestReviewComment(Expression expression) : base(expression)
+        internal PullRequestReviewComment(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PullRequestReviewCommentConnection.cs
+++ b/Octokit.GraphQL/Model/PullRequestReviewCommentConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PullRequestReviewCommentConnection : QueryableValue<PullRequestReviewCommentConnection>, IPagingConnection<PullRequestReviewComment>
     {
-        public PullRequestReviewCommentConnection(Expression expression) : base(expression)
+        internal PullRequestReviewCommentConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PullRequestReviewCommentEdge.cs
+++ b/Octokit.GraphQL/Model/PullRequestReviewCommentEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PullRequestReviewCommentEdge : QueryableValue<PullRequestReviewCommentEdge>
     {
-        public PullRequestReviewCommentEdge(Expression expression) : base(expression)
+        internal PullRequestReviewCommentEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PullRequestReviewConnection.cs
+++ b/Octokit.GraphQL/Model/PullRequestReviewConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PullRequestReviewConnection : QueryableValue<PullRequestReviewConnection>, IPagingConnection<PullRequestReview>
     {
-        public PullRequestReviewConnection(Expression expression) : base(expression)
+        internal PullRequestReviewConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PullRequestReviewEdge.cs
+++ b/Octokit.GraphQL/Model/PullRequestReviewEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PullRequestReviewEdge : QueryableValue<PullRequestReviewEdge>
     {
-        public PullRequestReviewEdge(Expression expression) : base(expression)
+        internal PullRequestReviewEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PullRequestReviewThread.cs
+++ b/Octokit.GraphQL/Model/PullRequestReviewThread.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PullRequestReviewThread : QueryableValue<PullRequestReviewThread>
     {
-        public PullRequestReviewThread(Expression expression) : base(expression)
+        internal PullRequestReviewThread(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PullRequestTimelineConnection.cs
+++ b/Octokit.GraphQL/Model/PullRequestTimelineConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PullRequestTimelineConnection : QueryableValue<PullRequestTimelineConnection>, IPagingConnection<PullRequestTimelineItem>
     {
-        public PullRequestTimelineConnection(Expression expression) : base(expression)
+        internal PullRequestTimelineConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PullRequestTimelineItem.cs
+++ b/Octokit.GraphQL/Model/PullRequestTimelineItem.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PullRequestTimelineItem : QueryableValue<PullRequestTimelineItem>, IUnion
     {
-        public PullRequestTimelineItem(Expression expression) : base(expression)
+        internal PullRequestTimelineItem(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PullRequestTimelineItemEdge.cs
+++ b/Octokit.GraphQL/Model/PullRequestTimelineItemEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PullRequestTimelineItemEdge : QueryableValue<PullRequestTimelineItemEdge>
     {
-        public PullRequestTimelineItemEdge(Expression expression) : base(expression)
+        internal PullRequestTimelineItemEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PullRequestTimelineItems.cs
+++ b/Octokit.GraphQL/Model/PullRequestTimelineItems.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PullRequestTimelineItems : QueryableValue<PullRequestTimelineItems>, IUnion
     {
-        public PullRequestTimelineItems(Expression expression) : base(expression)
+        internal PullRequestTimelineItems(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PullRequestTimelineItemsEdge.cs
+++ b/Octokit.GraphQL/Model/PullRequestTimelineItemsEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PullRequestTimelineItemsEdge : QueryableValue<PullRequestTimelineItemsEdge>
     {
-        public PullRequestTimelineItemsEdge(Expression expression) : base(expression)
+        internal PullRequestTimelineItemsEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Push.cs
+++ b/Octokit.GraphQL/Model/Push.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Push : QueryableValue<Push>
     {
-        public Push(Expression expression) : base(expression)
+        internal Push(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PushAllowance.cs
+++ b/Octokit.GraphQL/Model/PushAllowance.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PushAllowance : QueryableValue<PushAllowance>
     {
-        public PushAllowance(Expression expression) : base(expression)
+        internal PushAllowance(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PushAllowanceActor.cs
+++ b/Octokit.GraphQL/Model/PushAllowanceActor.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PushAllowanceActor : QueryableValue<PushAllowanceActor>, IUnion
     {
-        public PushAllowanceActor(Expression expression) : base(expression)
+        internal PushAllowanceActor(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PushAllowanceConnection.cs
+++ b/Octokit.GraphQL/Model/PushAllowanceConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PushAllowanceConnection : QueryableValue<PushAllowanceConnection>, IPagingConnection<PushAllowance>
     {
-        public PushAllowanceConnection(Expression expression) : base(expression)
+        internal PushAllowanceConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/PushAllowanceEdge.cs
+++ b/Octokit.GraphQL/Model/PushAllowanceEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class PushAllowanceEdge : QueryableValue<PushAllowanceEdge>
     {
-        public PushAllowanceEdge(Expression expression) : base(expression)
+        internal PushAllowanceEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RateLimit.cs
+++ b/Octokit.GraphQL/Model/RateLimit.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RateLimit : QueryableValue<RateLimit>
     {
-        public RateLimit(Expression expression) : base(expression)
+        internal RateLimit(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Reactable.cs
+++ b/Octokit.GraphQL/Model/Reactable.cs
@@ -53,7 +53,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubIReactable : QueryableValue<StubIReactable>, IReactable
     {
-        public StubIReactable(Expression expression) : base(expression)
+        internal StubIReactable(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReactingUserConnection.cs
+++ b/Octokit.GraphQL/Model/ReactingUserConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReactingUserConnection : QueryableValue<ReactingUserConnection>, IPagingConnection<User>
     {
-        public ReactingUserConnection(Expression expression) : base(expression)
+        internal ReactingUserConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReactingUserEdge.cs
+++ b/Octokit.GraphQL/Model/ReactingUserEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReactingUserEdge : QueryableValue<ReactingUserEdge>
     {
-        public ReactingUserEdge(Expression expression) : base(expression)
+        internal ReactingUserEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Reaction.cs
+++ b/Octokit.GraphQL/Model/Reaction.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Reaction : QueryableValue<Reaction>
     {
-        public Reaction(Expression expression) : base(expression)
+        internal Reaction(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReactionConnection.cs
+++ b/Octokit.GraphQL/Model/ReactionConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReactionConnection : QueryableValue<ReactionConnection>, IPagingConnection<Reaction>
     {
-        public ReactionConnection(Expression expression) : base(expression)
+        internal ReactionConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReactionEdge.cs
+++ b/Octokit.GraphQL/Model/ReactionEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReactionEdge : QueryableValue<ReactionEdge>
     {
-        public ReactionEdge(Expression expression) : base(expression)
+        internal ReactionEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReactionGroup.cs
+++ b/Octokit.GraphQL/Model/ReactionGroup.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReactionGroup : QueryableValue<ReactionGroup>
     {
-        public ReactionGroup(Expression expression) : base(expression)
+        internal ReactionGroup(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Ref.cs
+++ b/Octokit.GraphQL/Model/Ref.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Ref : QueryableValue<Ref>
     {
-        public Ref(Expression expression) : base(expression)
+        internal Ref(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RefConnection.cs
+++ b/Octokit.GraphQL/Model/RefConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RefConnection : QueryableValue<RefConnection>, IPagingConnection<Ref>
     {
-        public RefConnection(Expression expression) : base(expression)
+        internal RefConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RefEdge.cs
+++ b/Octokit.GraphQL/Model/RefEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RefEdge : QueryableValue<RefEdge>
     {
-        public RefEdge(Expression expression) : base(expression)
+        internal RefEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReferencedEvent.cs
+++ b/Octokit.GraphQL/Model/ReferencedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReferencedEvent : QueryableValue<ReferencedEvent>
     {
-        public ReferencedEvent(Expression expression) : base(expression)
+        internal ReferencedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReferencedSubject.cs
+++ b/Octokit.GraphQL/Model/ReferencedSubject.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReferencedSubject : QueryableValue<ReferencedSubject>, IUnion
     {
-        public ReferencedSubject(Expression expression) : base(expression)
+        internal ReferencedSubject(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RegistryPackageOwner.cs
+++ b/Octokit.GraphQL/Model/RegistryPackageOwner.cs
@@ -27,7 +27,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubIRegistryPackageOwner : QueryableValue<StubIRegistryPackageOwner>, IRegistryPackageOwner
     {
-        public StubIRegistryPackageOwner(Expression expression) : base(expression)
+        internal StubIRegistryPackageOwner(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RegistryPackageSearch.cs
+++ b/Octokit.GraphQL/Model/RegistryPackageSearch.cs
@@ -27,7 +27,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubIRegistryPackageSearch : QueryableValue<StubIRegistryPackageSearch>, IRegistryPackageSearch
     {
-        public StubIRegistryPackageSearch(Expression expression) : base(expression)
+        internal StubIRegistryPackageSearch(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Release.cs
+++ b/Octokit.GraphQL/Model/Release.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Release : QueryableValue<Release>
     {
-        public Release(Expression expression) : base(expression)
+        internal Release(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReleaseAsset.cs
+++ b/Octokit.GraphQL/Model/ReleaseAsset.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReleaseAsset : QueryableValue<ReleaseAsset>
     {
-        public ReleaseAsset(Expression expression) : base(expression)
+        internal ReleaseAsset(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReleaseAssetConnection.cs
+++ b/Octokit.GraphQL/Model/ReleaseAssetConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReleaseAssetConnection : QueryableValue<ReleaseAssetConnection>, IPagingConnection<ReleaseAsset>
     {
-        public ReleaseAssetConnection(Expression expression) : base(expression)
+        internal ReleaseAssetConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReleaseAssetEdge.cs
+++ b/Octokit.GraphQL/Model/ReleaseAssetEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReleaseAssetEdge : QueryableValue<ReleaseAssetEdge>
     {
-        public ReleaseAssetEdge(Expression expression) : base(expression)
+        internal ReleaseAssetEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReleaseConnection.cs
+++ b/Octokit.GraphQL/Model/ReleaseConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReleaseConnection : QueryableValue<ReleaseConnection>, IPagingConnection<Release>
     {
-        public ReleaseConnection(Expression expression) : base(expression)
+        internal ReleaseConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReleaseEdge.cs
+++ b/Octokit.GraphQL/Model/ReleaseEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReleaseEdge : QueryableValue<ReleaseEdge>
     {
-        public ReleaseEdge(Expression expression) : base(expression)
+        internal ReleaseEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RemoveOutsideCollaboratorPayload.cs
+++ b/Octokit.GraphQL/Model/RemoveOutsideCollaboratorPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RemoveOutsideCollaboratorPayload : QueryableValue<RemoveOutsideCollaboratorPayload>
     {
-        public RemoveOutsideCollaboratorPayload(Expression expression) : base(expression)
+        internal RemoveOutsideCollaboratorPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RemoveReactionPayload.cs
+++ b/Octokit.GraphQL/Model/RemoveReactionPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RemoveReactionPayload : QueryableValue<RemoveReactionPayload>
     {
-        public RemoveReactionPayload(Expression expression) : base(expression)
+        internal RemoveReactionPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RemoveStarPayload.cs
+++ b/Octokit.GraphQL/Model/RemoveStarPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RemoveStarPayload : QueryableValue<RemoveStarPayload>
     {
-        public RemoveStarPayload(Expression expression) : base(expression)
+        internal RemoveStarPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RemovedFromProjectEvent.cs
+++ b/Octokit.GraphQL/Model/RemovedFromProjectEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RemovedFromProjectEvent : QueryableValue<RemovedFromProjectEvent>
     {
-        public RemovedFromProjectEvent(Expression expression) : base(expression)
+        internal RemovedFromProjectEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RenamedTitleEvent.cs
+++ b/Octokit.GraphQL/Model/RenamedTitleEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RenamedTitleEvent : QueryableValue<RenamedTitleEvent>
     {
-        public RenamedTitleEvent(Expression expression) : base(expression)
+        internal RenamedTitleEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RenamedTitleSubject.cs
+++ b/Octokit.GraphQL/Model/RenamedTitleSubject.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RenamedTitleSubject : QueryableValue<RenamedTitleSubject>, IUnion
     {
-        public RenamedTitleSubject(Expression expression) : base(expression)
+        internal RenamedTitleSubject(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReopenedEvent.cs
+++ b/Octokit.GraphQL/Model/ReopenedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReopenedEvent : QueryableValue<ReopenedEvent>
     {
-        public ReopenedEvent(Expression expression) : base(expression)
+        internal ReopenedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Repository.cs
+++ b/Octokit.GraphQL/Model/Repository.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Repository : QueryableValue<Repository>
     {
-        public Repository(Expression expression) : base(expression)
+        internal Repository(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RepositoryCollaboratorConnection.cs
+++ b/Octokit.GraphQL/Model/RepositoryCollaboratorConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RepositoryCollaboratorConnection : QueryableValue<RepositoryCollaboratorConnection>, IPagingConnection<User>
     {
-        public RepositoryCollaboratorConnection(Expression expression) : base(expression)
+        internal RepositoryCollaboratorConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RepositoryCollaboratorEdge.cs
+++ b/Octokit.GraphQL/Model/RepositoryCollaboratorEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RepositoryCollaboratorEdge : QueryableValue<RepositoryCollaboratorEdge>
     {
-        public RepositoryCollaboratorEdge(Expression expression) : base(expression)
+        internal RepositoryCollaboratorEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RepositoryConnection.cs
+++ b/Octokit.GraphQL/Model/RepositoryConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RepositoryConnection : QueryableValue<RepositoryConnection>, IPagingConnection<Repository>
     {
-        public RepositoryConnection(Expression expression) : base(expression)
+        internal RepositoryConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RepositoryEdge.cs
+++ b/Octokit.GraphQL/Model/RepositoryEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RepositoryEdge : QueryableValue<RepositoryEdge>
     {
-        public RepositoryEdge(Expression expression) : base(expression)
+        internal RepositoryEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RepositoryInfo.cs
+++ b/Octokit.GraphQL/Model/RepositoryInfo.cs
@@ -141,7 +141,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubIRepositoryInfo : QueryableValue<StubIRepositoryInfo>, IRepositoryInfo
     {
-        public StubIRepositoryInfo(Expression expression) : base(expression)
+        internal StubIRepositoryInfo(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RepositoryInvitation.cs
+++ b/Octokit.GraphQL/Model/RepositoryInvitation.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RepositoryInvitation : QueryableValue<RepositoryInvitation>
     {
-        public RepositoryInvitation(Expression expression) : base(expression)
+        internal RepositoryInvitation(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RepositoryInvitationEdge.cs
+++ b/Octokit.GraphQL/Model/RepositoryInvitationEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RepositoryInvitationEdge : QueryableValue<RepositoryInvitationEdge>
     {
-        public RepositoryInvitationEdge(Expression expression) : base(expression)
+        internal RepositoryInvitationEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RepositoryNode.cs
+++ b/Octokit.GraphQL/Model/RepositoryNode.cs
@@ -30,7 +30,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubIRepositoryNode : QueryableValue<StubIRepositoryNode>, IRepositoryNode
     {
-        public StubIRepositoryNode(Expression expression) : base(expression)
+        internal StubIRepositoryNode(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RepositoryOwner.cs
+++ b/Octokit.GraphQL/Model/RepositoryOwner.cs
@@ -83,7 +83,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubIRepositoryOwner : QueryableValue<StubIRepositoryOwner>, IRepositoryOwner
     {
-        public StubIRepositoryOwner(Expression expression) : base(expression)
+        internal StubIRepositoryOwner(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RepositoryTopic.cs
+++ b/Octokit.GraphQL/Model/RepositoryTopic.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RepositoryTopic : QueryableValue<RepositoryTopic>
     {
-        public RepositoryTopic(Expression expression) : base(expression)
+        internal RepositoryTopic(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RepositoryTopicConnection.cs
+++ b/Octokit.GraphQL/Model/RepositoryTopicConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RepositoryTopicConnection : QueryableValue<RepositoryTopicConnection>, IPagingConnection<RepositoryTopic>
     {
-        public RepositoryTopicConnection(Expression expression) : base(expression)
+        internal RepositoryTopicConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RepositoryTopicEdge.cs
+++ b/Octokit.GraphQL/Model/RepositoryTopicEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RepositoryTopicEdge : QueryableValue<RepositoryTopicEdge>
     {
-        public RepositoryTopicEdge(Expression expression) : base(expression)
+        internal RepositoryTopicEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RequestReviewsPayload.cs
+++ b/Octokit.GraphQL/Model/RequestReviewsPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RequestReviewsPayload : QueryableValue<RequestReviewsPayload>
     {
-        public RequestReviewsPayload(Expression expression) : base(expression)
+        internal RequestReviewsPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RequestedReviewer.cs
+++ b/Octokit.GraphQL/Model/RequestedReviewer.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RequestedReviewer : QueryableValue<RequestedReviewer>, IUnion
     {
-        public RequestedReviewer(Expression expression) : base(expression)
+        internal RequestedReviewer(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/RerequestCheckSuitePayload.cs
+++ b/Octokit.GraphQL/Model/RerequestCheckSuitePayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class RerequestCheckSuitePayload : QueryableValue<RerequestCheckSuitePayload>
     {
-        public RerequestCheckSuitePayload(Expression expression) : base(expression)
+        internal RerequestCheckSuitePayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReviewDismissalAllowance.cs
+++ b/Octokit.GraphQL/Model/ReviewDismissalAllowance.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReviewDismissalAllowance : QueryableValue<ReviewDismissalAllowance>
     {
-        public ReviewDismissalAllowance(Expression expression) : base(expression)
+        internal ReviewDismissalAllowance(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReviewDismissalAllowanceActor.cs
+++ b/Octokit.GraphQL/Model/ReviewDismissalAllowanceActor.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReviewDismissalAllowanceActor : QueryableValue<ReviewDismissalAllowanceActor>, IUnion
     {
-        public ReviewDismissalAllowanceActor(Expression expression) : base(expression)
+        internal ReviewDismissalAllowanceActor(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReviewDismissalAllowanceConnection.cs
+++ b/Octokit.GraphQL/Model/ReviewDismissalAllowanceConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReviewDismissalAllowanceConnection : QueryableValue<ReviewDismissalAllowanceConnection>, IPagingConnection<ReviewDismissalAllowance>
     {
-        public ReviewDismissalAllowanceConnection(Expression expression) : base(expression)
+        internal ReviewDismissalAllowanceConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReviewDismissalAllowanceEdge.cs
+++ b/Octokit.GraphQL/Model/ReviewDismissalAllowanceEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReviewDismissalAllowanceEdge : QueryableValue<ReviewDismissalAllowanceEdge>
     {
-        public ReviewDismissalAllowanceEdge(Expression expression) : base(expression)
+        internal ReviewDismissalAllowanceEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReviewDismissedEvent.cs
+++ b/Octokit.GraphQL/Model/ReviewDismissedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReviewDismissedEvent : QueryableValue<ReviewDismissedEvent>
     {
-        public ReviewDismissedEvent(Expression expression) : base(expression)
+        internal ReviewDismissedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReviewRequest.cs
+++ b/Octokit.GraphQL/Model/ReviewRequest.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReviewRequest : QueryableValue<ReviewRequest>
     {
-        public ReviewRequest(Expression expression) : base(expression)
+        internal ReviewRequest(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReviewRequestConnection.cs
+++ b/Octokit.GraphQL/Model/ReviewRequestConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReviewRequestConnection : QueryableValue<ReviewRequestConnection>, IPagingConnection<ReviewRequest>
     {
-        public ReviewRequestConnection(Expression expression) : base(expression)
+        internal ReviewRequestConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReviewRequestEdge.cs
+++ b/Octokit.GraphQL/Model/ReviewRequestEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReviewRequestEdge : QueryableValue<ReviewRequestEdge>
     {
-        public ReviewRequestEdge(Expression expression) : base(expression)
+        internal ReviewRequestEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReviewRequestRemovedEvent.cs
+++ b/Octokit.GraphQL/Model/ReviewRequestRemovedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReviewRequestRemovedEvent : QueryableValue<ReviewRequestRemovedEvent>
     {
-        public ReviewRequestRemovedEvent(Expression expression) : base(expression)
+        internal ReviewRequestRemovedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/ReviewRequestedEvent.cs
+++ b/Octokit.GraphQL/Model/ReviewRequestedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class ReviewRequestedEvent : QueryableValue<ReviewRequestedEvent>
     {
-        public ReviewRequestedEvent(Expression expression) : base(expression)
+        internal ReviewRequestedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/SearchResultItem.cs
+++ b/Octokit.GraphQL/Model/SearchResultItem.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class SearchResultItem : QueryableValue<SearchResultItem>, IUnion
     {
-        public SearchResultItem(Expression expression) : base(expression)
+        internal SearchResultItem(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/SearchResultItemConnection.cs
+++ b/Octokit.GraphQL/Model/SearchResultItemConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class SearchResultItemConnection : QueryableValue<SearchResultItemConnection>, IPagingConnection<SearchResultItem>
     {
-        public SearchResultItemConnection(Expression expression) : base(expression)
+        internal SearchResultItemConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/SearchResultItemEdge.cs
+++ b/Octokit.GraphQL/Model/SearchResultItemEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class SearchResultItemEdge : QueryableValue<SearchResultItemEdge>
     {
-        public SearchResultItemEdge(Expression expression) : base(expression)
+        internal SearchResultItemEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/SmimeSignature.cs
+++ b/Octokit.GraphQL/Model/SmimeSignature.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class SmimeSignature : QueryableValue<SmimeSignature>
     {
-        public SmimeSignature(Expression expression) : base(expression)
+        internal SmimeSignature(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/StargazerConnection.cs
+++ b/Octokit.GraphQL/Model/StargazerConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class StargazerConnection : QueryableValue<StargazerConnection>, IPagingConnection<User>
     {
-        public StargazerConnection(Expression expression) : base(expression)
+        internal StargazerConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/StargazerEdge.cs
+++ b/Octokit.GraphQL/Model/StargazerEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class StargazerEdge : QueryableValue<StargazerEdge>
     {
-        public StargazerEdge(Expression expression) : base(expression)
+        internal StargazerEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Starrable.cs
+++ b/Octokit.GraphQL/Model/Starrable.cs
@@ -42,7 +42,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubIStarrable : QueryableValue<StubIStarrable>, IStarrable
     {
-        public StubIStarrable(Expression expression) : base(expression)
+        internal StubIStarrable(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/StarredRepositoryConnection.cs
+++ b/Octokit.GraphQL/Model/StarredRepositoryConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class StarredRepositoryConnection : QueryableValue<StarredRepositoryConnection>, IPagingConnection<Repository>
     {
-        public StarredRepositoryConnection(Expression expression) : base(expression)
+        internal StarredRepositoryConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/StarredRepositoryEdge.cs
+++ b/Octokit.GraphQL/Model/StarredRepositoryEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class StarredRepositoryEdge : QueryableValue<StarredRepositoryEdge>
     {
-        public StarredRepositoryEdge(Expression expression) : base(expression)
+        internal StarredRepositoryEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Status.cs
+++ b/Octokit.GraphQL/Model/Status.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Status : QueryableValue<Status>
     {
-        public Status(Expression expression) : base(expression)
+        internal Status(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/StatusContext.cs
+++ b/Octokit.GraphQL/Model/StatusContext.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class StatusContext : QueryableValue<StatusContext>
     {
-        public StatusContext(Expression expression) : base(expression)
+        internal StatusContext(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/SubmitPullRequestReviewPayload.cs
+++ b/Octokit.GraphQL/Model/SubmitPullRequestReviewPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class SubmitPullRequestReviewPayload : QueryableValue<SubmitPullRequestReviewPayload>
     {
-        public SubmitPullRequestReviewPayload(Expression expression) : base(expression)
+        internal SubmitPullRequestReviewPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Subscribable.cs
+++ b/Octokit.GraphQL/Model/Subscribable.cs
@@ -37,7 +37,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubISubscribable : QueryableValue<StubISubscribable>, ISubscribable
     {
-        public StubISubscribable(Expression expression) : base(expression)
+        internal StubISubscribable(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/SubscribedEvent.cs
+++ b/Octokit.GraphQL/Model/SubscribedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class SubscribedEvent : QueryableValue<SubscribedEvent>
     {
-        public SubscribedEvent(Expression expression) : base(expression)
+        internal SubscribedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/SuggestedReviewer.cs
+++ b/Octokit.GraphQL/Model/SuggestedReviewer.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class SuggestedReviewer : QueryableValue<SuggestedReviewer>
     {
-        public SuggestedReviewer(Expression expression) : base(expression)
+        internal SuggestedReviewer(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Tag.cs
+++ b/Octokit.GraphQL/Model/Tag.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Tag : QueryableValue<Tag>
     {
-        public Tag(Expression expression) : base(expression)
+        internal Tag(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Team.cs
+++ b/Octokit.GraphQL/Model/Team.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Team : QueryableValue<Team>
     {
-        public Team(Expression expression) : base(expression)
+        internal Team(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/TeamConnection.cs
+++ b/Octokit.GraphQL/Model/TeamConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class TeamConnection : QueryableValue<TeamConnection>, IPagingConnection<Team>
     {
-        public TeamConnection(Expression expression) : base(expression)
+        internal TeamConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/TeamEdge.cs
+++ b/Octokit.GraphQL/Model/TeamEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class TeamEdge : QueryableValue<TeamEdge>
     {
-        public TeamEdge(Expression expression) : base(expression)
+        internal TeamEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/TeamMemberConnection.cs
+++ b/Octokit.GraphQL/Model/TeamMemberConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class TeamMemberConnection : QueryableValue<TeamMemberConnection>, IPagingConnection<User>
     {
-        public TeamMemberConnection(Expression expression) : base(expression)
+        internal TeamMemberConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/TeamMemberEdge.cs
+++ b/Octokit.GraphQL/Model/TeamMemberEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class TeamMemberEdge : QueryableValue<TeamMemberEdge>
     {
-        public TeamMemberEdge(Expression expression) : base(expression)
+        internal TeamMemberEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/TeamRepositoryConnection.cs
+++ b/Octokit.GraphQL/Model/TeamRepositoryConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class TeamRepositoryConnection : QueryableValue<TeamRepositoryConnection>, IPagingConnection<Repository>
     {
-        public TeamRepositoryConnection(Expression expression) : base(expression)
+        internal TeamRepositoryConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/TeamRepositoryEdge.cs
+++ b/Octokit.GraphQL/Model/TeamRepositoryEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class TeamRepositoryEdge : QueryableValue<TeamRepositoryEdge>
     {
-        public TeamRepositoryEdge(Expression expression) : base(expression)
+        internal TeamRepositoryEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/TextMatch.cs
+++ b/Octokit.GraphQL/Model/TextMatch.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class TextMatch : QueryableValue<TextMatch>
     {
-        public TextMatch(Expression expression) : base(expression)
+        internal TextMatch(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/TextMatchHighlight.cs
+++ b/Octokit.GraphQL/Model/TextMatchHighlight.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class TextMatchHighlight : QueryableValue<TextMatchHighlight>
     {
-        public TextMatchHighlight(Expression expression) : base(expression)
+        internal TextMatchHighlight(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Topic.cs
+++ b/Octokit.GraphQL/Model/Topic.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Topic : QueryableValue<Topic>
     {
-        public Topic(Expression expression) : base(expression)
+        internal Topic(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/TopicConnection.cs
+++ b/Octokit.GraphQL/Model/TopicConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class TopicConnection : QueryableValue<TopicConnection>, IPagingConnection<Topic>
     {
-        public TopicConnection(Expression expression) : base(expression)
+        internal TopicConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/TopicEdge.cs
+++ b/Octokit.GraphQL/Model/TopicEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class TopicEdge : QueryableValue<TopicEdge>
     {
-        public TopicEdge(Expression expression) : base(expression)
+        internal TopicEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/TransferredEvent.cs
+++ b/Octokit.GraphQL/Model/TransferredEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class TransferredEvent : QueryableValue<TransferredEvent>
     {
-        public TransferredEvent(Expression expression) : base(expression)
+        internal TransferredEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Tree.cs
+++ b/Octokit.GraphQL/Model/Tree.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class Tree : QueryableValue<Tree>
     {
-        public Tree(Expression expression) : base(expression)
+        internal Tree(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/TreeEntry.cs
+++ b/Octokit.GraphQL/Model/TreeEntry.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class TreeEntry : QueryableValue<TreeEntry>
     {
-        public TreeEntry(Expression expression) : base(expression)
+        internal TreeEntry(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UnassignedEvent.cs
+++ b/Octokit.GraphQL/Model/UnassignedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UnassignedEvent : QueryableValue<UnassignedEvent>
     {
-        public UnassignedEvent(Expression expression) : base(expression)
+        internal UnassignedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UniformResourceLocatable.cs
+++ b/Octokit.GraphQL/Model/UniformResourceLocatable.cs
@@ -35,7 +35,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubIUniformResourceLocatable : QueryableValue<StubIUniformResourceLocatable>, IUniformResourceLocatable
     {
-        public StubIUniformResourceLocatable(Expression expression) : base(expression)
+        internal StubIUniformResourceLocatable(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UnknownSignature.cs
+++ b/Octokit.GraphQL/Model/UnknownSignature.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UnknownSignature : QueryableValue<UnknownSignature>
     {
-        public UnknownSignature(Expression expression) : base(expression)
+        internal UnknownSignature(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UnlabeledEvent.cs
+++ b/Octokit.GraphQL/Model/UnlabeledEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UnlabeledEvent : QueryableValue<UnlabeledEvent>
     {
-        public UnlabeledEvent(Expression expression) : base(expression)
+        internal UnlabeledEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UnlockLockablePayload.cs
+++ b/Octokit.GraphQL/Model/UnlockLockablePayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UnlockLockablePayload : QueryableValue<UnlockLockablePayload>
     {
-        public UnlockLockablePayload(Expression expression) : base(expression)
+        internal UnlockLockablePayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UnlockedEvent.cs
+++ b/Octokit.GraphQL/Model/UnlockedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UnlockedEvent : QueryableValue<UnlockedEvent>
     {
-        public UnlockedEvent(Expression expression) : base(expression)
+        internal UnlockedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UnpinnedEvent.cs
+++ b/Octokit.GraphQL/Model/UnpinnedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UnpinnedEvent : QueryableValue<UnpinnedEvent>
     {
-        public UnpinnedEvent(Expression expression) : base(expression)
+        internal UnpinnedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UnsubscribedEvent.cs
+++ b/Octokit.GraphQL/Model/UnsubscribedEvent.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UnsubscribedEvent : QueryableValue<UnsubscribedEvent>
     {
-        public UnsubscribedEvent(Expression expression) : base(expression)
+        internal UnsubscribedEvent(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/Updatable.cs
+++ b/Octokit.GraphQL/Model/Updatable.cs
@@ -30,7 +30,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubIUpdatable : QueryableValue<StubIUpdatable>, IUpdatable
     {
-        public StubIUpdatable(Expression expression) : base(expression)
+        internal StubIUpdatable(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UpdatableComment.cs
+++ b/Octokit.GraphQL/Model/UpdatableComment.cs
@@ -30,7 +30,7 @@ namespace Octokit.GraphQL.Model.Internal
 
     internal class StubIUpdatableComment : QueryableValue<StubIUpdatableComment>, IUpdatableComment
     {
-        public StubIUpdatableComment(Expression expression) : base(expression)
+        internal StubIUpdatableComment(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UpdateBranchProtectionRulePayload.cs
+++ b/Octokit.GraphQL/Model/UpdateBranchProtectionRulePayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UpdateBranchProtectionRulePayload : QueryableValue<UpdateBranchProtectionRulePayload>
     {
-        public UpdateBranchProtectionRulePayload(Expression expression) : base(expression)
+        internal UpdateBranchProtectionRulePayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UpdateCheckRunPayload.cs
+++ b/Octokit.GraphQL/Model/UpdateCheckRunPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UpdateCheckRunPayload : QueryableValue<UpdateCheckRunPayload>
     {
-        public UpdateCheckRunPayload(Expression expression) : base(expression)
+        internal UpdateCheckRunPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UpdateCheckSuitePreferencesPayload.cs
+++ b/Octokit.GraphQL/Model/UpdateCheckSuitePreferencesPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UpdateCheckSuitePreferencesPayload : QueryableValue<UpdateCheckSuitePreferencesPayload>
     {
-        public UpdateCheckSuitePreferencesPayload(Expression expression) : base(expression)
+        internal UpdateCheckSuitePreferencesPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UpdateProjectCardPayload.cs
+++ b/Octokit.GraphQL/Model/UpdateProjectCardPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UpdateProjectCardPayload : QueryableValue<UpdateProjectCardPayload>
     {
-        public UpdateProjectCardPayload(Expression expression) : base(expression)
+        internal UpdateProjectCardPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UpdateProjectColumnPayload.cs
+++ b/Octokit.GraphQL/Model/UpdateProjectColumnPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UpdateProjectColumnPayload : QueryableValue<UpdateProjectColumnPayload>
     {
-        public UpdateProjectColumnPayload(Expression expression) : base(expression)
+        internal UpdateProjectColumnPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UpdateProjectPayload.cs
+++ b/Octokit.GraphQL/Model/UpdateProjectPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UpdateProjectPayload : QueryableValue<UpdateProjectPayload>
     {
-        public UpdateProjectPayload(Expression expression) : base(expression)
+        internal UpdateProjectPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UpdatePullRequestReviewCommentPayload.cs
+++ b/Octokit.GraphQL/Model/UpdatePullRequestReviewCommentPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UpdatePullRequestReviewCommentPayload : QueryableValue<UpdatePullRequestReviewCommentPayload>
     {
-        public UpdatePullRequestReviewCommentPayload(Expression expression) : base(expression)
+        internal UpdatePullRequestReviewCommentPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UpdatePullRequestReviewPayload.cs
+++ b/Octokit.GraphQL/Model/UpdatePullRequestReviewPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UpdatePullRequestReviewPayload : QueryableValue<UpdatePullRequestReviewPayload>
     {
-        public UpdatePullRequestReviewPayload(Expression expression) : base(expression)
+        internal UpdatePullRequestReviewPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UpdateSubscriptionPayload.cs
+++ b/Octokit.GraphQL/Model/UpdateSubscriptionPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UpdateSubscriptionPayload : QueryableValue<UpdateSubscriptionPayload>
     {
-        public UpdateSubscriptionPayload(Expression expression) : base(expression)
+        internal UpdateSubscriptionPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UpdateTopicsPayload.cs
+++ b/Octokit.GraphQL/Model/UpdateTopicsPayload.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UpdateTopicsPayload : QueryableValue<UpdateTopicsPayload>
     {
-        public UpdateTopicsPayload(Expression expression) : base(expression)
+        internal UpdateTopicsPayload(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/User.cs
+++ b/Octokit.GraphQL/Model/User.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class User : QueryableValue<User>
     {
-        public User(Expression expression) : base(expression)
+        internal User(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UserConnection.cs
+++ b/Octokit.GraphQL/Model/UserConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UserConnection : QueryableValue<UserConnection>, IPagingConnection<User>
     {
-        public UserConnection(Expression expression) : base(expression)
+        internal UserConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UserContentEdit.cs
+++ b/Octokit.GraphQL/Model/UserContentEdit.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UserContentEdit : QueryableValue<UserContentEdit>
     {
-        public UserContentEdit(Expression expression) : base(expression)
+        internal UserContentEdit(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UserContentEditConnection.cs
+++ b/Octokit.GraphQL/Model/UserContentEditConnection.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UserContentEditConnection : QueryableValue<UserContentEditConnection>, IPagingConnection<UserContentEdit>
     {
-        public UserContentEditConnection(Expression expression) : base(expression)
+        internal UserContentEditConnection(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UserContentEditEdge.cs
+++ b/Octokit.GraphQL/Model/UserContentEditEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UserContentEditEdge : QueryableValue<UserContentEditEdge>
     {
-        public UserContentEditEdge(Expression expression) : base(expression)
+        internal UserContentEditEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Model/UserEdge.cs
+++ b/Octokit.GraphQL/Model/UserEdge.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// </summary>
     public class UserEdge : QueryableValue<UserEdge>
     {
-        public UserEdge(Expression expression) : base(expression)
+        internal UserEdge(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Mutation.cs
+++ b/Octokit.GraphQL/Mutation.cs
@@ -16,7 +16,7 @@ namespace Octokit.GraphQL
         {
         }
 
-        public Mutation(Expression expression) : base(expression)
+        internal Mutation(Expression expression) : base(expression)
         {
         }
 

--- a/Octokit.GraphQL/Query.cs
+++ b/Octokit.GraphQL/Query.cs
@@ -16,7 +16,7 @@ namespace Octokit.GraphQL
         {
         }
 
-        public Query(Expression expression) : base(expression)
+        internal Query(Expression expression) : base(expression)
         {
         }
 


### PR DESCRIPTION
This constructor is only ever called by another internal method.
It also generates a fair number of warnings in our code because it is public and not documented.
Easiest solution is to make it internal.