### PR TITLE
Add support for DateTime in queries

### DIFF
--- a/Octokit.GraphQL.Core/Core/Syntax/VariableDefinition.cs
+++ b/Octokit.GraphQL.Core/Core/Syntax/VariableDefinition.cs
@@ -31,6 +31,10 @@ namespace Octokit.GraphQL.Core.Syntax
             {
                 name = "Boolean";
             }
+            else if (type == typeof(DateTimeOffset))
+            {
+                name = "DateTime";
+            }
             else if (type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
             {
                 var inner = ToTypeName(type.GenericTypeArguments[0], false);

--- a/Octokit.GraphQL.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.UnitTests/QueryBuilderTests.cs
@@ -291,6 +291,24 @@ namespace Octokit.GraphQL.UnitTests
             Assert.Equal(expected, query.ToString(), ignoreLineEndingDifferences: true);
         }
 
+        [Fact]
+        public void Viewer_ContributionsCollection_FromToWithVariables()
+        {
+            var expected = @"query($start: DateTime, $end: DateTime) {
+  viewer {
+    contributionsCollection(from: $start, to: $end)
+  }
+}";
+
+            var expression = new Query()
+                .Viewer
+                .ContributionsCollection(from: Variable.Var("start"), to: Variable.Var("end"));
+
+            var query = expression.Compile();
+
+            Assert.Equal(expected, query.ToString(), ignoreLineEndingDifferences: true);
+        }
+
         [Fact(Skip = "Not yet working")]
         public void Search_User_Name_Via_Edges()
         {


### PR DESCRIPTION
The QuerySerializer would generate a stack overflow without a special case for the `DateTimeOffset` type.

Note: the [DateTime][1] scalar type is [mapped to System.DateTimeOffset][2] in the model generator.

The motivation behind this change is that you need to set `from` and `to` in order to [get more than one year of contributions][3].

[1]: https://developer.github.com/v4/scalar/datetime/
[2]: https://github.com/octokit/octokit.graphql.net/blob/285fc1b2ce0b2dde72a4fa6abb5154778bbbe86d/Octokit.GraphQL.Core.Generation/Utilities/TypeUtilities.cs#L131
[3]: https://github.community/t5/GitHub-API-Development-and/Are-pullRequestContributions-limited/m-p/32096#M3044