### PR TITLE
Update integration tests

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -37,6 +37,12 @@ jobs:
     - name: Run Octokit.GraphQL.Core.Generation.UnitTests
       run: dotnet test -c ${{ env.config }} --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Octokit.GraphQL]Octokit.GraphQL.*" .\Octokit.GraphQL.Core.Generation.UnitTests\Octokit.GraphQL.Core.Generation.UnitTests.csproj
 
+    - name: Run Octokit.GraphQL.IntegrationTests
+      run: dotnet test -c ${{ env.config }} --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Octokit.GraphQL]Octokit.GraphQL.*" .\Octokit.GraphQL.IntegrationTests\Octokit.GraphQL.IntegrationTests.csproj
+      env:
+        OCTOKIT_GQL_OAUTHTOKEN: "${{ secrets.OCTOKIT_GQL_OAUTHTOKEN }}"
+        OCTOKIT_GQL_GITHUBUSERNAME: "${{ secrets.OCTOKIT_GQL_GITHUBUSERNAME }}"
+
     - name: Create package using .nuspec
       run: dotnet pack Octokit.GraphQL.Pack/Octokit.GraphQL.Pack.csproj --output ${{ env.PackageOutputPath }}
       

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -37,12 +37,6 @@ jobs:
     - name: Run Octokit.GraphQL.Core.Generation.UnitTests
       run: dotnet test -c ${{ env.config }} --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Octokit.GraphQL]Octokit.GraphQL.*" .\Octokit.GraphQL.Core.Generation.UnitTests\Octokit.GraphQL.Core.Generation.UnitTests.csproj
 
-    - name: Run Octokit.GraphQL.IntegrationTests
-      run: dotnet test -c ${{ env.config }} --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Octokit.GraphQL]Octokit.GraphQL.*" .\Octokit.GraphQL.IntegrationTests\Octokit.GraphQL.IntegrationTests.csproj
-      env:
-        OCTOKIT_GQL_OAUTHTOKEN: "${{ secrets.OCTOKIT_GQL_OAUTHTOKEN }}"
-        OCTOKIT_GQL_GITHUBUSERNAME: "${{ secrets.OCTOKIT_GQL_GITHUBUSERNAME }}"
-
     - name: Create package using .nuspec
       run: dotnet pack Octokit.GraphQL.Pack/Octokit.GraphQL.Pack.csproj --output ${{ env.PackageOutputPath }}
       

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,6 +3,14 @@ name: Integration tests
 on:
   push:
 
+  # Runs at 00:00 UTC every day
+  schedule:
+    - cron: '0 */24 * * *'  
+
+  # Runs when repository is starred
+  watch:
+    types: [started]  
+
 env:
   config: Release
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,28 @@
+name: Integration tests
+
+on:
+  push:
+
+env:
+  config: Release
+
+jobs:
+  integration-tests:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.101
+
+    - name: Build using .NET Core
+      run: dotnet build Octokit.GraphQL.sln -c ${{ env.config }}
+
+    - name: Run integration tests
+      run: dotnet test -c ${{ env.config }} --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[Octokit.GraphQL]Octokit.GraphQL.*" .\Octokit.GraphQL.IntegrationTests\Octokit.GraphQL.IntegrationTests.csproj
+      env:
+        OCTOKIT_GQL_OAUTHTOKEN: "${{ secrets.OCTOKIT_GQL_OAUTHTOKEN }}"
+        OCTOKIT_GQL_GITHUBUSERNAME: "${{ secrets.OCTOKIT_GQL_GITHUBUSERNAME }}"

--- a/Octokit.GraphQL.IntegrationTests/Queries/ErrorTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/ErrorTests.cs
@@ -41,8 +41,10 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
         [IntegrationTest]
         public async Task Should_Throw_Correct_Error_For_Invalid_Repository_Name()
         {
+            var owner = "octokit";
+            var name = "bad_repository";
             var query = new Query()
-                .Repository(owner: "octokit", name: "bad_repository")
+                .Repository(owner: owner, name: name)
                 .Issues(first: 3)
                 .Nodes
                 .Select(i => new
@@ -52,7 +54,7 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
                 });
 
             var ex = await Assert.ThrowsAnyAsync<ResponseDeserializerException>(async () => await Connection.Run(query));
-            Assert.Equal("Could not resolve to a Repository with the name 'bad_repository'.", ex.Message);
+            Assert.Equal($"Could not resolve to a Repository with the name '{owner}/{name}'.", ex.Message);
             Assert.Equal(1, ex.Line);
             Assert.Equal(7, ex.Column);
         }

--- a/Octokit.GraphQL.IntegrationTests/Queries/PullRequestTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/PullRequestTests.cs
@@ -151,11 +151,22 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
             var query = new Query()
                 .Repository(owner: "octokit", name: "octokit.net")
                 .PullRequest(number: 1)
-                .Select(pr => pr.BaseRef != null ? pr.BaseRef.Repository.Owner.Login : null);
+                .Select(pr => new
+                {
+                    Owner = pr.BaseRef != null ? pr.BaseRef.Repository.Owner.Login : null,
+                    BaseRefNotNull = pr.BaseRef != null
+                });
 
             var result = await Connection.Run(query);
 
-            Assert.Equal("octokit", result);
+            if(result.BaseRefNotNull)
+            {
+                Assert.Equal("octokit", result.Owner);
+            }
+            else
+            {
+                Assert.Null(result.Owner);
+            }
         }
 
         [IntegrationTest]

--- a/Octokit.GraphQL.IntegrationTests/Queries/PullRequestTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/PullRequestTests.cs
@@ -138,11 +138,22 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
             var query = new Query()
                 .Repository(owner: "octokit", name: "octokit.net")
                 .PullRequest(number: 1)
-                .Select(pr => pr.BaseRef != null ? pr.BaseRef.Name : null);
+                .Select(pr => new
+                {
+                    BaseRefName = pr.BaseRef != null ? pr.BaseRef.Name : null,
+                    BaseRefNotNull = pr.BaseRef != null
+                });
 
             var result = await Connection.Run(query);
 
-            Assert.Equal("master", result);
+            if (result.BaseRefNotNull)
+            {
+                Assert.Equal("main", result.BaseRefName);
+            }
+            else
+            {
+                Assert.Null(result.BaseRefName);
+            }
         }
 
         [IntegrationTest]
@@ -159,7 +170,7 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
 
             var result = await Connection.Run(query);
 
-            if(result.BaseRefNotNull)
+            if (result.BaseRefNotNull)
             {
                 Assert.Equal("octokit", result.Owner);
             }

--- a/Octokit.GraphQL.IntegrationTests/Queries/RepositoryTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/RepositoryTests.cs
@@ -285,8 +285,8 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
                 });
 
             var testModelObject = await Connection.Run(query);
-            Assert.Equal("alanjrogers", testModelObject.Member.StringField1);
-            Assert.Equal("alanjrogers", testModelObject.MentionableUser.StringField1);
+            Assert.Equal("anaisbetts", testModelObject.Member.StringField1);
+            Assert.Equal("anaisbetts", testModelObject.MentionableUser.StringField1);
         }
 
         [IntegrationTest]

--- a/Octokit.GraphQL.IntegrationTests/Queries/RepositoryTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/RepositoryTests.cs
@@ -285,7 +285,7 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
                 });
 
             var testModelObject = await Connection.Run(query);
-            Assert.Equal("anaisbetts", testModelObject.Member.StringField1);
+            Assert.Equal("alanjrogers", testModelObject.Member.StringField1);
             Assert.Equal("anaisbetts", testModelObject.MentionableUser.StringField1);
         }
 

--- a/Octokit.GraphQL.IntegrationTests/Queries/RepositoryTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/RepositoryTests.cs
@@ -285,8 +285,8 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
                 });
 
             var testModelObject = await Connection.Run(query);
-            Assert.Equal("bkeepers", testModelObject.Member.StringField1);
-            Assert.Equal("bkeepers", testModelObject.MentionableUser.StringField1);
+            Assert.Equal("alanjrogers", testModelObject.Member.StringField1);
+            Assert.Equal("alanjrogers", testModelObject.MentionableUser.StringField1);
         }
 
         [IntegrationTest]

--- a/Octokit.GraphQL.IntegrationTests/Queries/ViewerTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/ViewerTests.cs
@@ -53,8 +53,8 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
             Assert.NotNull(graphqlUser);
 
             Assert.Equal(apiUser.AvatarUrl, graphqlUser.AvatarUrl);
-            Assert.Equal(apiUser.Bio ?? string.Empty, graphqlUser.Bio);
-            Assert.Equal(apiUser.Company ?? string.Empty, graphqlUser.Company);
+            Assert.Equal(apiUser.Bio, graphqlUser.Bio);
+            Assert.Equal(apiUser.Company, graphqlUser.Company);
 
             Assert.Equal(apiUser.CreatedAt.ToUniversalTime(), graphqlUser.CreatedAt.ToUniversalTime());
 


### PR DESCRIPTION
Fix integration tests and make them run on a schedule.

- Run integrations tests on push
- Run integrations tests every day
- Run integrations tests when the repository is starred
- Fix integration test to look for `main` branch _or_ `BaseRef == null`
- Allow user `Bio` and `Company` to be null (same as `Octokit.net`)
- Update the user names we look for in some tests (we should target a less dynamic repo!)