### PR TITLE
Fix multi-paged queries

### DIFF
--- a/Octokit.GraphQL.Core/Core/PagedSubquery.cs
+++ b/Octokit.GraphQL.Core/Core/PagedSubquery.cs
@@ -128,13 +128,14 @@ namespace Octokit.GraphQL.Core
             {
                 var more = await base.RunPage(cancellationToken).ConfigureAwait(false);
 
-                if (!more)
+                if (Result == null) return more;
+                
+                foreach (var i in (IList)Result)
                 {
-                    foreach (var i in (IList)Result)
-                    {
-                        addResult(i);
-                    }
+                    addResult(i);
                 }
+
+                Result = default;
 
                 return more;
             }

--- a/Octokit.GraphQL.Core/Core/PagedSubquery.cs
+++ b/Octokit.GraphQL.Core/Core/PagedSubquery.cs
@@ -115,7 +115,8 @@ namespace Octokit.GraphQL.Core
                 string after,
                 IDictionary<string, object> variables,
                 Action<object> addResult)
-                : base(owner, connection, variables ?? new Dictionary<string, object>())
+                : base(owner, connection, variables?.ToDictionary(x => x.Key, x => x.Value) ?? 
+                                          new Dictionary<string, object>())
             {
                 Variables["__id"] = id;
                 Variables["__after"] = after;

--- a/Octokit.GraphQL.IntegrationTests/Queries/IssueTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/IssueTests.cs
@@ -201,7 +201,7 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
         {
             var query = new Query()
                 .Repository(owner: "octokit", name: "octokit.net")
-                .Issues().AllPages(50)
+                .Issues().AllPages(100)
                 .Select(issue => new
                 {
                     issue.Id,
@@ -222,7 +222,7 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
         {
             var query = new Query()
                 .Repository(owner: "octokit", name: "octokit.net")
-                .Issues().AllPages(50)
+                .Issues().AllPages(100)
                 .Select(issue => new
                 {
                     issue.Id,

--- a/Octokit.GraphQL.IntegrationTests/Queries/RepositoryTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/RepositoryTests.cs
@@ -175,7 +175,7 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
 
             var repositoryName = (await Connection.Run(query)).OrderByDescending(s => s).First();
 
-            Assert.Equal("webhooks-methods.js", repositoryName);
+            Assert.Equal("webhooks.net", repositoryName);
         }
 
         [IntegrationTest]
@@ -260,7 +260,7 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
 
             var testModelObject = (await Connection.Run(query)).OrderByDescending(s => s.StringField1).First();
 
-            Assert.Equal("webhooks-methods.js", testModelObject.StringField1);
+            Assert.Equal("webhooks.net", testModelObject.StringField1);
         }
 
         [IntegrationTest]

--- a/Octokit.GraphQL.IntegrationTests/Queries/ViewerTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/ViewerTests.cs
@@ -55,7 +55,7 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
             Assert.NotNull(graphqlUser);
 
             Assert.Equal(apiUser.AvatarUrl.Split("?").First(), graphqlUser.AvatarUrl.Split("?").First());
-            Assert.Equal(apiUser.Bio, graphqlUser.Bio);
+            Assert.Equal(apiUser.Bio ?? string.Empty, graphqlUser.Bio);
             Assert.Equal(apiUser.Company, graphqlUser.Company);
 
             Assert.Equal(apiUser.CreatedAt.ToUniversalTime(), graphqlUser.CreatedAt.ToUniversalTime());


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #227

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Using `AllPages` to query multi-page result sets would only ever query at most 2 pages of results: the first, top level query, and one invocation of each subquery.
* This is because in a `PagedSubquery`, the `pageInfo` structure was never examined to see if there were any more pages to fetch, and so the caller would only ever call it for one page of results.
* In addition, the `PagedSubquery` code would only append `Results` to the parent collection when it had (theoretically) finished paginating. *But* each invocation of `RunPage` overwrites the `Results` variable and so everything but the last page would have been lost.

Pseudocode for the previous `RunPage` logic for both `PagedQuery` and `PagedSubquery` (they share an implementation of this logic):

```
if (first invocation)
{
  run this query
  examine the results for any _nested_ entities which report as hasNextPage (<-- Note it doesn't check if the top level results set hasNextPage)
  push any such nested entities onto a stack of runners to be processed
}
else
{
  call RunPage on the next Runner in the stack
}
```

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* This PR adds a `hasMore` field to record if the given `Runner` has more results it needs to process
* The `RunPage` logic given above is extended to check that flag before continuing on to process the stack of `Runners`
```
if (first invocation || hasMore)
{
  if (first invocation)
    initialise
  run this query
  examine the results for any _nested_ entities which report as hasNextPage
  push any such nested entities onto a stack of runners to be processed
}
else
{
  call RunPage on the next Runner in the stack
}
```
* Every invocation of `RunPage` on `PagedSubquery` now appends any new results to the parent collection, and clears it to make sure the next invocation is clean.
* Additionally fixed a bug where the `Variables` passed into `PagedSubquery.Runner` weren't copied to a new `Dictionary`

### Other information
<!-- Any other information that is important to this PR  -->

* This seems to fix the `IssueTests` integration tests for me

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

