### PR TITLE
Fix ArgumentException in conditional expressions 

### DIFF
--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -1264,6 +1264,26 @@ fragment issueTitle on Issue {
             Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);
         }
 
+        [Fact]
+        public void Repository_Parent_ConditionalExpression()
+        {
+            var expected = @"query {
+  repository(owner: ""foo"", name: ""bar"") {
+    parent {
+      name
+    }
+  }
+}";
+
+            var expression = new Query()
+                .Repository("foo", "bar")
+                .Select(repository => repository.Parent == null ? null : repository.Parent.Name);
+
+            var query = expression.Compile();
+
+            Assert.Equal(expected, query.ToString(2), ignoreLineEndingDifferences: true);
+        }
+
         class TestModelObject
         {
             public string StringField1;

--- a/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -204,7 +204,7 @@ namespace Octokit.GraphQL.Core.Builders
             }
             else if (!falseNull)
             {
-                ifTrue = Expression.Constant(null, ifFalse.Type);
+                ifTrue = Expression.Constant(null, node.Type);
             }
 
             if (!falseNull)
@@ -213,14 +213,14 @@ namespace Octokit.GraphQL.Core.Builders
             }
             else if (!trueNull)
             {
-                ifFalse = Expression.Constant(null, ifTrue.Type);
+                ifFalse = Expression.Constant(null, node.Type);
             }
 
             return Expression.Condition(
                 test,
                 ifTrue,
                 ifFalse,
-                !IsNullConstant(ifTrue) ? ifTrue.Type : ifFalse.Type);
+                node.Type);
         }
 
         protected override Expression VisitExtension(Expression node)


### PR DESCRIPTION
Before this commit, the following exception might be thrown:
> System.ArgumentException: Argument types do not match  
>   at System.Linq.Expressions.Expression.Condition(Expression test, Expression ifTrue, Expression ifFalse, Type type)
