### PR TITLE
Do not serialize null properties

### DIFF
--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -388,7 +388,7 @@ namespace Octokit.GraphQL.Core.UnitTests
         [Fact]
         public void InputObject_Parameter_With_Null_Field()
         {
-            var expected = "query{addComment(input:{subjectId:\"x\",body:null,clientMutationId:\"1\"}){body}}";
+            var expected = "query{addComment(input:{subjectId:\"x\",clientMutationId:\"1\"}){body}}";
 
             var input = new AddCommentInput
             {
@@ -578,7 +578,7 @@ namespace Octokit.GraphQL.Core.UnitTests
         [Fact]
         public void Double_Quotes_In_InputObject_Arg_Are_Escaped()
         {
-            var expected = "query{addComment(input:{subjectId:\"\",body:null,clientMutationId:\"string with \\\"quotes\\\" in it\"}){body}}";
+            var expected = "query{addComment(input:{subjectId:\"\",clientMutationId:\"string with \\\"quotes\\\" in it\"}){body}}";
 
             var expression = new Query()
                 .AddComment(new AddCommentInput { ClientMutationId = "string with \"quotes\" in it" })
@@ -592,7 +592,7 @@ namespace Octokit.GraphQL.Core.UnitTests
         [Fact]
         public void Backslash_In_InputObject_Arg_Is_Escaped()
         {
-            var expected = "query{addComment(input:{subjectId:\"\",body:null,clientMutationId:\"string with \\\\ in it\"}){body}}";
+            var expected = "query{addComment(input:{subjectId:\"\",clientMutationId:\"string with \\\\ in it\"}){body}}";
 
             var expression = new Query()
                 .AddComment(new AddCommentInput { ClientMutationId = "string with \\ in it" })

--- a/Octokit.GraphQL.Core/Core/Serializers/QuerySerializer.cs
+++ b/Octokit.GraphQL.Core/Core/Serializers/QuerySerializer.cs
@@ -247,26 +247,34 @@ namespace Octokit.GraphQL.Core.Serializers
                     //Cache Hit
                 }
 
+                var openedBrace = false;
+
                 for (var index = 0; index < properties.Length; index++)
                 {
                     var property = properties[index];
 
-                    if (index == 0)
-                    {
-                        OpenBrace(builder);
-                    }
-                    else
-                    {
-                        builder.Append(",");
-                    }
+                    var propertyValue = property.Item2.Invoke(value, null);
 
-                    builder.Append(property.Item1.LowerFirstCharacter()).Append(colon);
-                    SerializeValue(builder, property.Item2.Invoke(value, null));
-
-                    if (index + 1 == properties.Length)
+                    if (propertyValue != null)
                     {
-                        CloseBrace(builder);
+                        if(openedBrace)
+                        {
+                            builder.Append(',');
+                        }
+                        else
+                        {
+                            OpenBrace(builder);
+                            openedBrace = true;
+                        }
+
+                        builder.Append(property.Item1.LowerFirstCharacter()).Append(colon);
+                        SerializeValue(builder, propertyValue);
                     }
+                }
+
+                if(openedBrace)
+                {
+                    CloseBrace(builder);
                 }
             }
         }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #292 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* All Input properties are serialized, even when they are `null`.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Input properties with a `null` value are not serialized.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

I am unsure whether this is a breaking change as I don't know if the deserializer on the other end is dependent on these properties being present.

----

