### PR TITLE
feat|fix: adding attribute to skip null properties

### DIFF
--- a/src/Octokit.GraphQL.Core/Core/Serializers/SerializeIfNotNullAttribute.cs
+++ b/src/Octokit.GraphQL.Core/Core/Serializers/SerializeIfNotNullAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Octokit.GraphQL.Core.Serializers
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class SerializeIfNotNull : Attribute
+    {
+    }
+}

--- a/src/Octokit.GraphQL/Model/RuleParametersInput.cs
+++ b/src/Octokit.GraphQL/Model/RuleParametersInput.cs
@@ -1,7 +1,6 @@
 namespace Octokit.GraphQL.Model
 {
-    using System;
-    using System.Collections.Generic;
+    using Core.Serializers;
 
     /// <summary>
     /// Specifies the parameters for a `RepositoryRule` object. Only one of the fields should be specified.
@@ -11,51 +10,61 @@ namespace Octokit.GraphQL.Model
         /// <summary>
         /// Parameters used for the `update` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public UpdateParametersInput Update { get; set; }
 
         /// <summary>
         /// Parameters used for the `required_deployments` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public RequiredDeploymentsParametersInput RequiredDeployments { get; set; }
 
         /// <summary>
         /// Parameters used for the `pull_request` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public PullRequestParametersInput PullRequest { get; set; }
 
         /// <summary>
         /// Parameters used for the `required_status_checks` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public RequiredStatusChecksParametersInput RequiredStatusChecks { get; set; }
 
         /// <summary>
         /// Parameters used for the `commit_message_pattern` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public CommitMessagePatternParametersInput CommitMessagePattern { get; set; }
 
         /// <summary>
         /// Parameters used for the `commit_author_email_pattern` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public CommitAuthorEmailPatternParametersInput CommitAuthorEmailPattern { get; set; }
 
         /// <summary>
         /// Parameters used for the `committer_email_pattern` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public CommitterEmailPatternParametersInput CommitterEmailPattern { get; set; }
 
         /// <summary>
         /// Parameters used for the `branch_name_pattern` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public BranchNamePatternParametersInput BranchNamePattern { get; set; }
 
         /// <summary>
         /// Parameters used for the `tag_name_pattern` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public TagNamePatternParametersInput TagNamePattern { get; set; }
 
         /// <summary>
         /// Parameters used for the `workflows` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public WorkflowsParametersInput Workflows { get; set; }
     }
 }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #320

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

All attributes in the [RuleParametersInput](https://github.com/octokit/octokit.graphql.net/blob/main/src/Octokit.GraphQL/Model/RuleParametersInput.cs) were serialized regardless of their `null` value. This caused the GitHub calls to fail as GitHub incorrectly assumed we were specifying multiple rules at once.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Adding the `[SerializeIfNotNull]` attribute which can be applied to properties serialized by the [QuerySerializer](https://github.com/octokit/octokit.graphql.net/blob/main/src/Octokit.GraphQL.Core/Core/Serializers/QuerySerializer.cs) to indicate they should never be serialized when `null`.

As a proof of concept and bug fix, the [RuleParameterInput](https://github.com/octokit/octokit.graphql.net/blob/main/src/Octokit.GraphQL/Model/RuleParametersInput.cs) used in the creation of rulesets for the repository was failing due to `null` properties being serialized into the final output. This code now functions as expected.

I did not make a global change to no longer serialized all `null` values as I anticipate that there are "side effects" we depend on where there are expected `null` serializations that will break if such a change is made. This is contrary to the changes proposed in https://github.com/octokit/octokit.graphql.net/pull/319 which do not serialize all `null` properties passed in.

This is an "opt-in" feature that does not disturb the greater ecosystem that may depend on these "side effects". It is also backwards compatible as the rulesets are the only code using this and it was completely failing at the time of creating this PR.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

