### PR TITLE
[MAINT]: Update default Accept header

### DIFF
--- a/src/Octokit.GraphQL.Core.UnitTests/ConnectionTests.cs
+++ b/src/Octokit.GraphQL.Core.UnitTests/ConnectionTests.cs
@@ -74,7 +74,7 @@ namespace Octokit.GraphQL.Core.UnitTests
         }
 
         [Theory]
-        [InlineData("Accept", "application/vnd.github.antiope-preview+json")]
+        [InlineData("Accept", "application/vnd.github+json")]
         [InlineData("Authorization", "bearer my-token")]
         [InlineData("User-Agent", "Octokit.GraphQL.Core.Tests/1.0.0")]
         public static async Task Run_Specifies_Http_Headers(string name, string expected)

--- a/src/Octokit.GraphQL.Core/Connection.cs
+++ b/src/Octokit.GraphQL.Core/Connection.cs
@@ -13,7 +13,7 @@ namespace Octokit.GraphQL
     /// </summary>
     public class Connection : IConnection
     {
-        private const string DefaultMediaType = "application/vnd.github.antiope-preview+json";
+        private const string DefaultMediaType = "application/vnd.github+json";
 
         /// <summary>
         /// Gets the address of the GitHub GraphQL API.


### PR DESCRIPTION
Stop using a [graduated preview API](https://developer.github.com/changes/2020-10-01-graduate-antiope-preview/).

Resolves #334.

----

### Before the change?

* Requests send `Accept: application/vnd.github.antiope-preview+json`

### After the change?

* Requests send `Accept: application/vnd.github+json`

### Pull request checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----

