### PR TITLE
Update nuspec to use spdx expression for license

### DIFF
--- a/Octokit.GraphQL.nuspec
+++ b/Octokit.GraphQL.nuspec
@@ -6,7 +6,7 @@
     <authors>GitHub</authors>
     <owners>GitHub</owners>
     <repository type="git" url="https://github.com/octokit/octokit.graphql.net" />
-    <licenseUrl>https://github.com/octokit/octokit.graphql.net/blob/HEAD/LICENSE.md</licenseUrl>
+    <license type="expression">MIT</license>
     <projectUrl>https://github.com/octokit/octokit.graphql.net</projectUrl>
     <iconUrl>https://f.cloud.github.com/assets/19977/1441274/160fba8c-41a9-11e3-831d-61d88fa886f4.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #339 

----

### Before the change?

* The nuget package contains the `licenseUrl`. This is a deprecated field that should be replaced.

### After the change?

* The package uses the `license` field specifying the appropriate SPDX expression (`MIT`).

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No

----

